### PR TITLE
Calendar widget update handling improved

### DIFF
--- a/src/org/metawatch/manager/Monitors.java
+++ b/src/org/metawatch/manager/Monitors.java
@@ -104,7 +104,10 @@ public class Monitors {
 	private static ContentObserverCalls contentObserverCalls;
 	static ContentResolver contentResolverCalls;
 	
-	//public static int gmailCount = 0;
+	private static ContentObserverAppointments contentObserverAppointments;
+	static ContentResolver contentResolverAppointments;
+
+  //public static int gmailCount = 0;
 	static Hashtable<String, Integer> gmailUnreadCounts = new Hashtable<String, Integer>();
 	
 	public static LocationManager locationManager;
@@ -114,7 +117,9 @@ public class Monitors {
 	
 	private static BroadcastReceiver batteryLevelReceiver;
 	
-	public static class WeatherData {
+	public static boolean calendarChanged = false;
+
+  public static class WeatherData {
 		public static boolean updating = false;
 		public static boolean received = false;
 		public static String icon;
@@ -239,6 +244,13 @@ public class Monitors {
 		} catch (Exception x) {
 		}
 	
+		try {
+			contentObserverAppointments = new ContentObserverAppointments(context);
+			Uri uri = Uri.parse("content://com.android.calendar/calendars/");
+			contentResolverAppointments = context.getContentResolver();
+			contentResolverAppointments.registerContentObserver(uri, true, contentObserverAppointments);
+		} catch (Exception x) {
+			}
 		
 		// temporary one time update
 		updateWeatherData(context);
@@ -700,7 +712,27 @@ public class Monitors {
 		}
 	}
 	
-	private static class NetworkLocationListener implements LocationListener {
+	private static class ContentObserverAppointments extends ContentObserver {
+
+		Context context;
+
+		public ContentObserverAppointments(Context context) {
+			super(null);
+			this.context = context;     
+		}
+
+		@Override
+		public void onChange(boolean selfChange) {
+			super.onChange(selfChange);     
+			// change in calendar database
+			if (Preferences.logging) Log.d(MetaWatch.TAG, "calendar change");
+				calendarChanged = true;
+				Idle.updateLcdIdle(context);
+				calendarChanged = false;
+			}
+		}
+
+		private static class NetworkLocationListener implements LocationListener {
 
 		Context context;
 		

--- a/src/org/metawatch/manager/Utils.java
+++ b/src/org/metawatch/manager/Utils.java
@@ -98,6 +98,7 @@ public class Utils {
 	static public String Meeting_Title = "---";
 	static public String Meeting_Location = "---";
 	static public long Meeting_EndTimestamp;
+	static public long Meeting_StartTimestamp;
 	
 	public static String getContactNameFromNumber(Context context, String number) {
 		
@@ -271,6 +272,7 @@ public class Utils {
 
 					c.close();
 					begintemp = eventCursor.getLong(1);
+					Meeting_StartTimestamp = begintemp;
 					MeetingTime = new SimpleDateFormat("HH:mm").format(begintemp);
 					Meeting_EndTimestamp = eventCursor.getLong(2);
 


### PR DESCRIPTION
Hi benjymous,

I noticed that the calendar widget was not updated until the next meeting was over. This happens only if my new option readCalendarDuringMeeting is false. I changed this to the intended behaviour (only disallow updates while the meeting is ongoing).

Additionally, I added a content observer that updates the calendar widget if a change in the calendar database occurs (e.g., if a new appointment is added by the user).

Bye

Matthias
