### PR TITLE
Fix destructive scrolling in the app blacklist.

### DIFF
--- a/src/org/metawatch/manager/AppBlacklist.java
+++ b/src/org/metawatch/manager/AppBlacklist.java
@@ -1,6 +1,7 @@
 package org.metawatch.manager;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -46,8 +47,10 @@ public class AppBlacklist extends Activity {
 		protected List<AppInfo> doInBackground(Void... params) {
 			SharedPreferences sharedPreferences = PreferenceManager
 					.getDefaultSharedPreferences(AppBlacklist.this);
-			String blacklist = sharedPreferences.getString("appBlacklist",
-					DEFAULT_BLACKLIST);
+			String[] blacklist = sharedPreferences.getString("appBlacklist",
+					DEFAULT_BLACKLIST).split(",");
+			Arrays.sort(blacklist);
+			
 			PackageManager pm = getPackageManager();
 			List<PackageInfo> packages = pm.getInstalledPackages(0);
 			List<AppInfo> appInfos = new ArrayList<AppInfo>();
@@ -64,7 +67,8 @@ public class AppBlacklist extends Activity {
 				appInfo.name = pi.applicationInfo.loadLabel(pm).toString();
 				appInfo.icon = pi.applicationInfo.loadIcon(pm);
 				appInfo.packageName = pi.packageName;
-				appInfo.isBlacklisted = blacklist.contains(pi.packageName);
+				appInfo.isBlacklisted = 
+					(Arrays.binarySearch(blacklist, pi.packageName) >= 0);
 				appInfos.add(appInfo);
 			}
 			Collections.sort(appInfos);

--- a/src/org/metawatch/manager/AppBlacklist.java
+++ b/src/org/metawatch/manager/AppBlacklist.java
@@ -61,31 +61,20 @@ public class AppBlacklist extends Activity {
 					continue;
 				}
 				AppInfo appInfo = new AppInfo();
-				appInfo.packageInfo = pi;
-				appInfo.name = appInfo.packageInfo.applicationInfo
-						.loadLabel(pm).toString();
-				appInfo.icon = appInfo.packageInfo.applicationInfo.loadIcon(pm);
+				appInfo.name = pi.applicationInfo.loadLabel(pm).toString();
+				appInfo.icon = pi.applicationInfo.loadIcon(pm);
+				appInfo.packageName = pi.packageName;
 				appInfo.isBlacklisted = blacklist.contains(pi.packageName);
 				appInfos.add(appInfo);
 			}
 			Collections.sort(appInfos);
-
-			// for (AppInfo appInfo : appInfos) {
-			// if (Preferences.logging) Log.d(MetaWatch.TAG, "appName='" + appInfo.name
-			// + "' packageName='" + appInfo.packageInfo.packageName +
-			// "' selected="
-			// + appInfo.selected);
-			// }
 
 			return appInfos;
 		}
 
 		@Override
 		protected void onPostExecute(List<AppInfo> appInfos) {
-
 			ListView listView = (ListView) findViewById(android.R.id.list);
-			// listView.setAdapter(new ArrayAdapter<String>(this,
-			// android.R.layout.simple_list_item_1, menuList));
 			listView.setAdapter(new BlacklistAdapter(appInfos));
 			AppBlacklist.this.appInfos = appInfos;
 			pdWait.dismiss();
@@ -97,7 +86,7 @@ public class AppBlacklist extends Activity {
 	public class AppInfo implements Comparable<AppInfo> {
 		String name;
 		Drawable icon;
-		PackageInfo packageInfo;
+		String packageName;
 		boolean isBlacklisted;
 
 		public int compareTo(AppInfo another) {
@@ -160,7 +149,7 @@ public class AppBlacklist extends Activity {
 					if (sb.length() > 0) {
 						sb.append(",");
 					}
-					sb.append(appInfo.packageInfo.packageName);
+					sb.append(appInfo.packageName);
 				}
 			}
 			SharedPreferences sharedPreferences = PreferenceManager
@@ -171,7 +160,6 @@ public class AppBlacklist extends Activity {
 			editor.commit();		
 			if (Preferences.logging) Log.d(MetaWatch.TAG, "App blacklist: " + blacklist);
 		} catch (Exception e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 	}

--- a/src/org/metawatch/manager/AppBlacklist.java
+++ b/src/org/metawatch/manager/AppBlacklist.java
@@ -118,6 +118,10 @@ public class AppBlacklist extends Activity {
 			final AppInfo appInfo = apps.get(position);
 			icon.setImageDrawable(appInfo.icon);
 			appName.setText(appInfo.name);
+			
+			// Remove any previous listener to not confuse the system...
+			checkbox.setOnCheckedChangeListener(null);
+			// ...otherwise this row triggers for the old app when the View is reused.
 			checkbox.setChecked(appInfo.isBlacklisted);
 			checkbox.setOnCheckedChangeListener(new OnCheckedChangeListener() {
 				public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {

--- a/src/org/metawatch/manager/MetaWatchAccessibilityService.java
+++ b/src/org/metawatch/manager/MetaWatchAccessibilityService.java
@@ -1,5 +1,7 @@
 package org.metawatch.manager;
 
+import java.util.Arrays;
+
 import org.metawatch.manager.MetaWatchService.Preferences;
 
 import android.accessibilityservice.AccessibilityService;
@@ -129,11 +131,12 @@ public class MetaWatchAccessibilityService extends AccessibilityService {
 			/* Some other notification */
 			if (sharedPreferences.getBoolean("NotifyOtherNotification", true)) {
 	
-				String appBlacklist = sharedPreferences.getString("appBlacklist",
-						AppBlacklist.DEFAULT_BLACKLIST);
+				String[] appBlacklist = sharedPreferences.getString("appBlacklist",
+						AppBlacklist.DEFAULT_BLACKLIST).split(",");
+				Arrays.sort(appBlacklist);
 	
 				/* Ignore if on blacklist */
-				if (appBlacklist.contains(packageName)) {
+				if (Arrays.binarySearch(appBlacklist, packageName) >= 0) {
 					if (Preferences.logging) Log.d(MetaWatch.TAG,
 							"onAccessibilityEvent(): App is blacklisted, ignoring.");
 					return;


### PR DESCRIPTION
Views, and therefore also CheckBoxes, are reused when scrolling in the list, and the CheckBox value could be changed to the value of one app while the CheckBox was still connected to another app, changing the value of that app.

Because of this, scrolling in the blacklist view (for me, on Android 4.0.4, at least) completely destroyed the list content...

I also threw in a commit that makes blacklist matching exact. The previous method could match substrings of package names (happens for example for most "pro version keys").
