### PR TITLE
Some minor enhancements

### DIFF
--- a/src/org/metawatch/manager/Idle.java
+++ b/src/org/metawatch/manager/Idle.java
@@ -106,13 +106,17 @@ public class Idle {
 			}
 
 			if (Preferences.displayWidgetRowSeparator) {
-				int i = (pageIndex==0 ? -1:0);
-				yPos = 0 + space;
+				yPos = space/2; // Center the separators between rows.
+				if (pageIndex == 0) {
+					yPos += 32;
+					drawLine(canvas, yPos);
+				}
+				int i = 0;
 				for(WidgetRow row : rows) {
+					if (++i == rows.size())
+						continue;
 					yPos += row.getHeight() + space;
-					i++;
-					if (i!=rows.size())
-						drawLine(canvas, yPos);
+					drawLine(canvas, yPos);
 				}
 			}
 			

--- a/src/org/metawatch/manager/MetaWatchAccessibilityService.java
+++ b/src/org/metawatch/manager/MetaWatchAccessibilityService.java
@@ -100,8 +100,8 @@ public class MetaWatchAccessibilityService extends AccessibilityService {
 			}
 			
 			
-			/* Deezer track notification */
-			if (packageName.equals("deezer.android.app")) {
+			/* Deezer or Spotify track notification */
+			if (packageName.equals("deezer.android.app") || packageName.equals("com.spotify.mobile.android.ui")) {
 				
 				String text = notification.tickerText.toString().trim();
 				


### PR DESCRIPTION
- Add Spotify metadata support, simply by adding Spotify's package name to Deezer's if statement in the accessibility service. The notification text is formatted the same in the two apps.
- Enhance the rendering of widget row separators, centering them between widget rows and handling different sized widget rows better (especially on the first page, where they wouldn't behave at all before in that case).
