### PR TITLE
Calendar widget enhancements

### DIFF
--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -133,19 +133,6 @@
  			android:defaultValue="3"
  			/>			
 		<CheckBoxPreference
-			android:title="@string/settings_Read_calendar_during_meeting"
-			android:key="ReadCalendarDuringMeeting"
-			android:summary="@string/settings_Read_calendar_during_meeting_desc"
-			android:defaultValue="true"
-			/>
-		<EditTextPreference
-			android:title="@string/settings_Read_calendar_min_duration_to_meeting_end"
-			android:key="ReadCalendarMinDurationToMeetingEnd"
-			android:summary="@string/settings_Read_calendar_min_duration_to_meeting_end_desc"
-			android:numeric="integer"
-			android:defaultValue="15"
-			/>
-		<CheckBoxPreference
 			android:title="@string/settings_Batterylow"
 			android:key="NotifyBatterylow"
 			android:summary="@string/settings_Batterylow_desc"
@@ -293,6 +280,19 @@
 			android:key="DisplayWidgetRowSeparator"
 			android:summary="@string/settings_Display_widget_row_separator_desc"
 			android:defaultValue="false"
+			/>
+		<CheckBoxPreference
+			android:title="@string/settings_Read_calendar_during_meeting"
+			android:key="ReadCalendarDuringMeeting"
+			android:summary="@string/settings_Read_calendar_during_meeting_desc"
+			android:defaultValue="true"
+			/>
+		<EditTextPreference
+			android:title="@string/settings_Read_calendar_min_duration_to_meeting_end"
+			android:key="ReadCalendarMinDurationToMeetingEnd"
+			android:summary="@string/settings_Read_calendar_min_duration_to_meeting_end_desc"
+			android:numeric="integer"
+			android:defaultValue="15"
 			/>
 		<CheckBoxPreference
 			android:title="@string/settings_Display_location_in_small_calendar_widget"

--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -301,6 +301,12 @@
 			android:defaultValue="false"
 			/>
 		<CheckBoxPreference
+			android:title="@string/settings_Event_date_in_calendar_widget"
+			android:key="EventDateInCalendarWidget"
+			android:summary="@string/settings_Event_date_in_calendar_widget_desc"
+			android:defaultValue="false"
+			/>
+		<CheckBoxPreference
 			android:title="@string/settings_Overlay_weather_text"
 			android:key="OverlayWeatherText"
 			android:summary="@string/settings_Overlay_weather_text_desc"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="settings_Read_calendar_min_duration_to_meeting_end_desc">Duration in minutes to the end of an ongoing meeting before calendar read is allowed</string>
     <string name="settings_Display_location_in_small_calendar_widget">Display location in small calendar widget</string>
     <string name="settings_Display_location_in_small_calendar_widget_desc">Displays the location instead of the date in the 24x32 next calendar appointment widget if there is enough space</string>
+    <string name="settings_Event_date_in_calendar_widget">Event date in calendar widget</string>
+    <string name="settings_Event_date_in_calendar_widget_desc">Displays the event date instead of today\'s date in the *x32 calendar widgets (when showing an event)</string>
     <string name="settings_Display_widget_row_separator">Display separator line</string>
     <string name="settings_Display_widget_row_separator_desc">Draws a separator line between widget rows</string>
     <string name="settings_Overlay_weather_text">Overlay text in weather widget</string>

--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -173,6 +173,7 @@ public class MetaWatchService extends Service {
 		public static boolean readCalendarDuringMeeting = true;
 		public static int readCalendarMinDurationToMeetingEnd = 15;
 		public static boolean displayLocationInSmallCalendarWidget = false;
+		public static boolean eventDateInCalendarWidget = false;
 		public static boolean displayWidgetRowSeparator = false;
 		public static boolean overlayWeatherText = false;
 	}
@@ -250,6 +251,8 @@ public class MetaWatchService extends Service {
 				Integer.toString(Preferences.readCalendarMinDurationToMeetingEnd)));
 		Preferences.displayLocationInSmallCalendarWidget = sharedPreferences.getBoolean("DisplayLocationInSmallCalendarWidget",
 				Preferences.displayLocationInSmallCalendarWidget);
+		Preferences.eventDateInCalendarWidget = sharedPreferences.getBoolean("EventDateInCalendarWidget",
+				Preferences.eventDateInCalendarWidget);
 		Preferences.displayWidgetRowSeparator = sharedPreferences.getBoolean("DisplayWidgetRowSeparator",
 				Preferences.displayWidgetRowSeparator);
 		Preferences.overlayWeatherText = sharedPreferences.getBoolean("OverlayWeatherText",

--- a/src/org/metawatch/manager/widgets/CalendarWidget.java
+++ b/src/org/metawatch/manager/widgets/CalendarWidget.java
@@ -188,7 +188,11 @@ public class CalendarWidget implements InternalWidget {
 			else 
 			{
 				Calendar c = Calendar.getInstance(); 
-				int dayOfMonth = c.get(Calendar.DAY_OF_MONTH); 
+				if ((Preferences.eventDateInCalendarWidget)&&
+						(!meetingTime.equals("None"))) {
+					c.setTimeInMillis(meetingStartTimestamp);
+				}
+				int dayOfMonth = c.get(Calendar.DAY_OF_MONTH);
 				if(dayOfMonth<10) {
 					canvas.drawText(""+dayOfMonth, 12, 16, paintNumerals);
 				}


### PR DESCRIPTION
- Move "Read calendar during meeting" settings from Notifications to Watch Widgets (they only concern the widgets, right?).
- Add a preference for selecting what date to show in the *x32 calendar widgets. Today's date (default and old behaviour) or the date of the event.
