### PR TITLE
Make ImageViewer capable of handling the ACTION_SEND intent (in addition to the ACTION_VIEW intent).

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -55,6 +55,11 @@
 				<category android:name="android.intent.category.DEFAULT" />
 				<data android:mimeType="image/*" />
 			</intent-filter>
+			<intent-filter>
+				<action	android:name="android.intent.action.SEND" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<data android:mimeType="image/*" />
+			</intent-filter>
 		</activity>
 		<activity 
 			android:label="Send to Watch"

--- a/src/org/metawatch/manager/ImageViewer.java
+++ b/src/org/metawatch/manager/ImageViewer.java
@@ -42,6 +42,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -52,13 +53,27 @@ public class ImageViewer extends Activity {
 		super.onCreate(savedInstanceState);
 		
         Intent i = getIntent();
+        String action = i.getAction();
+        Uri u = null;
+
+        if (action.equals(Intent.ACTION_VIEW)) {
+        	u = i.getData();
+        } else if (action.equals(Intent.ACTION_SEND)) {
+        	u = i.getParcelableExtra(Intent.EXTRA_STREAM);
+        } else {
+        	if (Preferences.logging) Log.e(MetaWatch.TAG, "Unknown intent: " + action);
+        	finish();
+        	return;
+        }
         
-        if (Preferences.logging) Log.d(MetaWatch.TAG, "action: " + i.getAction());                        
-        if (Preferences.logging) Log.d(MetaWatch.TAG, "data: "+ i.getData().getPath() );
+        if (Preferences.logging) {
+        	Log.d(MetaWatch.TAG, "action: " + i.getAction());
+        	Log.d(MetaWatch.TAG, "data: "+ u.getPath() );
+        }
         
         InputStream is;
 		try {
-			is = getContentResolver().openInputStream(i.getData());
+			is = getContentResolver().openInputStream(u);
 			
 	        BitmapFactory.Options options = new BitmapFactory.Options();       
 	        Bitmap bmp = BitmapFactory.decodeStream(is, null, options);
@@ -73,7 +88,6 @@ public class ImageViewer extends Activity {
 	        }
         
 		} catch (FileNotFoundException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
         


### PR DESCRIPTION
This adds "Send to watch" in the share menu of the Gallery app, for example (at least in Android 4.0.4). I thought it was missing there (and the needed change was quite minimal).
