### PR TITLE
New widget features and notification fixes

### DIFF
--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -215,12 +215,13 @@
 			android:summary="Enable the light when a notification or incoming call is displayed"
 			android:defaultValue="false"
 			/>
-			
-		<CheckBoxPreference
-			android:title="Sticky Notifications"
-			android:key="stickyNotifications"
-			android:summary="Use sticky notifications (that stay on screen until manually dismissed)"
-			android:defaultValue="true"
+		
+		<EditTextPreference
+			android:title="Notification Timeout"
+			android:key="notificationTimeout"
+			android:summary="Default time non-sticky notifications wait before returning to idle screen (seconds)"
+			android:numeric="integer"
+			android:defaultValue="5"
 			/>
 				
 	</PreferenceScreen>
@@ -240,12 +241,12 @@
 	<PreferenceScreen
 		android:title="@string/settings_Digital"
 		>
-		<EditTextPreference
-			android:title="Notification Timeout"
-			android:key="notificationTimeout"
-			android:summary="Default time non-sticky notifications wait before returning to idle screen (seconds)"
-			android:numeric="integer"
-			android:defaultValue="5"
+			
+		<CheckBoxPreference
+			android:title="Sticky Notifications"
+			android:key="stickyNotifications"
+			android:summary="Use sticky notifications (that stay on screen until manually dismissed)"
+			android:defaultValue="true"
 			/>
 			
 		<EditTextPreference

--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -270,6 +270,13 @@
 			android:defaultValue="false"
 			/>
 
+		<CheckBoxPreference
+			android:title="Clock on Every Page"
+			android:key="ClockOnEveryPage"
+			android:summary="Show the clock on all widget pages"
+			android:defaultValue="false"
+			/>
+
 	</PreferenceScreen>	
 	
 	<PreferenceScreen

--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -263,6 +263,13 @@
 			android:defaultValue="false"
 			/>
 
+	    <CheckBoxPreference
+			android:title="@string/settings_Display_widget_row_separator"
+			android:key="DisplayWidgetRowSeparator"
+			android:summary="@string/settings_Display_widget_row_separator_desc"
+			android:defaultValue="false"
+			/>
+
 	</PreferenceScreen>	
 	
 	<PreferenceScreen
@@ -275,12 +282,6 @@
 			android:summary="Reset widgets to default layout"
 			/>
 	    
-	    <CheckBoxPreference
-			android:title="@string/settings_Display_widget_row_separator"
-			android:key="DisplayWidgetRowSeparator"
-			android:summary="@string/settings_Display_widget_row_separator_desc"
-			android:defaultValue="false"
-			/>
 		<CheckBoxPreference
 			android:title="@string/settings_Read_calendar_during_meeting"
 			android:key="ReadCalendarDuringMeeting"

--- a/res/layout/test.xml
+++ b/res/layout/test.xml
@@ -9,6 +9,7 @@
     	<Preference android:key="sms_start" android:title="SMS Start (LCD/OLED)"/>
     	<Preference android:key="sms_stop" android:title="SMS Stop (LCD/OLED)"/>
     	<Preference android:key="sms" android:title="SMS (LCD/OLED)"/>
+    	<Preference android:key="mms" android:title="MMS (LCD/OLED)"/>
     	<Preference android:key="k9" android:title="K9 (LCD/OLED)"/>
     	<Preference android:key="gmail" android:title="Gmail (OLED)"/>
     	<Preference android:key="gmail_short" android:title="Gmail Short (OLED)"/>

--- a/src/org/metawatch/manager/Idle.java
+++ b/src/org/metawatch/manager/Idle.java
@@ -88,7 +88,9 @@ public class Idle {
 			Canvas canvas = new Canvas(bitmap);
 			canvas.drawColor(Color.WHITE);	
 			
-			if(watchType == WatchType.DIGITAL && preview && pageIndex==0) {
+			boolean showClock = (pageIndex==0 || Preferences.clockOnEveryPage);
+			
+			if(watchType == WatchType.DIGITAL && preview && showClock) {
 				canvas.drawBitmap(Utils.loadBitmapFromAssets(context, "dummy_clock.png"), 0, 0, null);
 			} 
 			
@@ -97,8 +99,8 @@ public class Idle {
 				totalHeight += row.getHeight();
 			}
 						
-			int space = (watchType == WatchType.DIGITAL) ? (((pageIndex==0 ? 64:96) - totalHeight) / (rows.size()+1)) : 0;
-			int yPos = (watchType == WatchType.DIGITAL) ? (pageIndex==0 ? 32:0) + space : 0;
+			int space = (watchType == WatchType.DIGITAL) ? (((showClock ? 64:96) - totalHeight) / (rows.size()+1)) : 0;
+			int yPos = (watchType == WatchType.DIGITAL) ? (showClock ? 32:0) + space : 0;
 			
 			for(WidgetRow row : rows) {
 				row.draw(widgetData, canvas, yPos);
@@ -107,7 +109,7 @@ public class Idle {
 
 			if (watchType == WatchType.DIGITAL && Preferences.displayWidgetRowSeparator) {
 				yPos = space/2; // Center the separators between rows.
-				if (pageIndex == 0) {
+				if (showClock) {
 					yPos += 32;
 					drawLine(canvas, yPos);
 				}
@@ -224,7 +226,7 @@ public class Idle {
 			if(screenSize+row.getHeight() > maxScreenSize) {
 				screens.add(i.new WidgetPage(screenRow, screens.size()));
 				screenRow = new ArrayList<WidgetRow>();
-				screenSize = 0;
+				screenSize = (Preferences.clockOnEveryPage ? 32 : 0);
 			}
 			screenRow.add(row);
 			screenSize += row.getHeight();
@@ -281,12 +283,15 @@ public class Idle {
 		}
 		
 		final int mode = getScreenMode();
+		boolean showClock = false;
 		
-		if(mode ==  MetaWatchService.WatchBuffers.IDLE)
+		if(mode == MetaWatchService.WatchBuffers.IDLE) {
 			updateIdlePages(context, refresh);
+			showClock = (currentPage==0 || Preferences.clockOnEveryPage);
+		}
 		
 		Protocol.sendLcdBitmap(createIdle(context), mode);
-		Protocol.configureIdleBufferSize(currentPage==0);
+		Protocol.configureIdleBufferSize(showClock);
 		Protocol.updateLcdDisplay(mode);
 	}
 	

--- a/src/org/metawatch/manager/Idle.java
+++ b/src/org/metawatch/manager/Idle.java
@@ -105,7 +105,7 @@ public class Idle {
 				yPos += row.getHeight() + space;
 			}
 
-			if (Preferences.displayWidgetRowSeparator) {
+			if (watchType == WatchType.DIGITAL && Preferences.displayWidgetRowSeparator) {
 				yPos = space/2; // Center the separators between rows.
 				if (pageIndex == 0) {
 					yPos += 32;

--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -176,6 +176,7 @@ public class MetaWatchService extends Service {
 		public static boolean eventDateInCalendarWidget = false;
 		public static boolean displayWidgetRowSeparator = false;
 		public static boolean overlayWeatherText = false;
+		public static boolean clockOnEveryPage = false;
 	}
 
 	public final class WatchType {
@@ -257,6 +258,8 @@ public class MetaWatchService extends Service {
 				Preferences.displayWidgetRowSeparator);
 		Preferences.overlayWeatherText = sharedPreferences.getBoolean("OverlayWeatherText",
 				Preferences.overlayWeatherText);
+		Preferences.clockOnEveryPage = sharedPreferences.getBoolean("ClockOnEveryPage",
+				Preferences.clockOnEveryPage);
 
 		try {
 			Preferences.fontSize = Integer.valueOf(sharedPreferences.getString(

--- a/src/org/metawatch/manager/NotificationBuilder.java
+++ b/src/org/metawatch/manager/NotificationBuilder.java
@@ -89,7 +89,7 @@ public class NotificationBuilder {
 		VibratePattern vibratePattern = createVibratePatternFromPreference(context, "settingsSMSNumberBuzzes");
 		if (MetaWatchService.watchType == WatchType.DIGITAL) {
 			Bitmap bitmap = smartLines(context, "message.bmp", "MMS from", new String[] {name});		
-			Notification.addBitmapNotification(context, bitmap, vibratePattern, 4000);
+			Notification.addBitmapNotification(context, bitmap, vibratePattern, Notification.getDefaultNotificationTimeout(context));
 		} else {
 			byte[] scroll = new byte[800];
 			int len = Protocol.createOled2linesLong(context, name, scroll);

--- a/src/org/metawatch/manager/Test.java
+++ b/src/org/metawatch/manager/Test.java
@@ -144,6 +144,13 @@ public class Test extends PreferenceActivity {
 		    	return true;
 			}
 		});
+        
+		preferenceScreen.findPreference("mms").setOnPreferenceClickListener(new OnPreferenceClickListener() {	
+			public boolean onPreferenceClick(Preference arg0) {
+			 	NotificationBuilder.createMMS(context, "555-123-4567");
+			 	return true;
+			}
+		});
     	           
 		preferenceScreen.findPreference("testShortMessage").setOnPreferenceClickListener(new OnPreferenceClickListener() {	
 			public boolean onPreferenceClick(Preference arg0) {


### PR DESCRIPTION
- Disable widget row separators for analog watches and move the setting for it to the Digital Watch section. (This may be wrong, as I don't have an analog watch, but I imagine them being either invisible or just in the way.)
- Add a new setting to the Digital Watch section that toggles showing the clock on all widget pages (not app pages). Default is not to do so, which also is the old behaviour. I found this new mode quite useful and pleasing. :)
- Add a test for MMS notifications.
- Fix timeout value for MMS notifications on the digital watch (erroneously set to 4000 ms, now uses the setting).
- Switch places for the "Notification Timeout" and "Sticky Notifications" settings. The first one affects both watches but was placed in the "Digital Watch" category. The latter one only affects the digital watch but was placed in the "Notifications" category. I switched their places.
