### PR TITLE
Avoid instantly disappearing notifications (and a minor cleanup)

### DIFF
--- a/src/org/metawatch/manager/Call.java
+++ b/src/org/metawatch/manager/Call.java
@@ -108,7 +108,7 @@ public class Call {
 			canvas.restore();
 			
 			Protocol.sendLcdBitmap(bitmap, MetaWatchService.WatchBuffers.NOTIFICATION);		
-			Protocol.updateLcdDisplay(2);
+			Protocol.updateLcdDisplay(MetaWatchService.WatchBuffers.NOTIFICATION);
 		} else {
 			Bitmap icon = Utils.loadBitmapFromAssets(context, "phone.bmp");
 			Notification

--- a/src/org/metawatch/manager/CallVibrate.java
+++ b/src/org/metawatch/manager/CallVibrate.java
@@ -44,7 +44,7 @@ public class CallVibrate implements Runnable {
 			if (Preferences.notifyLight)
 				Protocol.ledChange(true);
 			if (MetaWatchService.watchType == WatchType.DIGITAL)
-				Protocol.updateLcdDisplay(2);
+				Protocol.updateLcdDisplay(MetaWatchService.WatchBuffers.NOTIFICATION);
 			else
 				Protocol.updateOledsNotification();
 			

--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -729,7 +729,13 @@ public class MetaWatchService extends Service {
 																	// event
 			    if (Preferences.logging) Log.d(MetaWatch.TAG,
                         "MetaWatchService.readFromDevice(): status change");
-				if (bytes[4] == 0x11) {
+			    if (bytes[4] == 0x01) {
+					if (Preferences.logging) Log.d(MetaWatch.TAG,
+							"MetaWatchService.readFromDevice(): mode changed");
+					synchronized (Notification.modeChanged) {
+						Notification.modeChanged.notify();
+					}
+			    } else if (bytes[4] == 0x11) {
 					if (Preferences.logging) Log.d(MetaWatch.TAG,
 							"MetaWatchService.readFromDevice(): scroll request notification");
 

--- a/src/org/metawatch/manager/Notification.java
+++ b/src/org/metawatch/manager/Notification.java
@@ -98,7 +98,7 @@ public class Notification {
 							continue;
 						}
 
-						Protocol.updateLcdDisplay(2);
+						Protocol.updateLcdDisplay(MetaWatchService.WatchBuffers.NOTIFICATION);
 
 						if (notification.vibratePattern.vibrate)
 							Protocol.vibrate(notification.vibratePattern.on,

--- a/src/org/metawatch/manager/Notification.java
+++ b/src/org/metawatch/manager/Notification.java
@@ -178,20 +178,27 @@ public class Notification {
 						}
 
 					}
-
-					lastNotification = notification;
-
-					/* Give some space between notifications. */
 					
+					/* Send button configuration for sticky notifications. */
 					if (notification.timeout < 0) {
 						notifyButtonPress = NOTIFICATION_NONE;
-						long startTicks = System.currentTimeMillis(); 
 						if (notification.bitmaps!=null & notification.bitmaps.length>1) {
 							Protocol.enableButton(0, 0, NOTIFICATION_UP, 2); // Right top immediate
 							Protocol.enableButton(1, 0, NOTIFICATION_DOWN, 2); // Right middle immediate
 						}
 						Protocol.enableButton(2, 0, NOTIFICATION_DISMISS, 2); // Right bottom immediate
+					}
 
+					lastNotification = notification;
+
+					/* Wait until the watch shows the notification before starting the timeout. */
+					synchronized (Notification.modeChanged) {
+						modeChanged.wait(30000);
+					}
+
+					/* Do the timeout and button handling. */
+					if (notification.timeout < 0) {
+						long startTicks = System.currentTimeMillis(); 
 						if (Preferences.logging) Log.d(MetaWatch.TAG,
 								"NotificationSender.run(): Notification sent, waiting for dismiss " );
 						
@@ -238,6 +245,7 @@ public class Notification {
 						
 					}
 					else {
+						
 						if (Preferences.logging) Log.d(MetaWatch.TAG,
 								"NotificationSender.run(): Notification sent, sleeping for "
 										+ notification.timeout + "ms");
@@ -249,6 +257,8 @@ public class Notification {
 					if (MetaWatchService.WatchModes.CALL == false) {
 						exitNotification(context);
 					}
+					
+					/* Leave some space between notifications. */
 					Thread.sleep(2000);
 
 				} catch (InterruptedException ie) {
@@ -328,6 +338,7 @@ public class Notification {
 
 	public static Object scrollRequest = new Object();
 	public static Object buttonPressed = new Object();
+	public static Object modeChanged = new Object();
 
 	public static class NotificationType {
 		Bitmap[] bitmaps;

--- a/src/org/metawatch/manager/Test.java
+++ b/src/org/metawatch/manager/Test.java
@@ -246,7 +246,7 @@ public class Test extends PreferenceActivity {
 		preferenceScreen.findPreference("load_template").setOnPreferenceClickListener(new OnPreferenceClickListener() {	
 			public boolean onPreferenceClick(Preference arg0) {
 		    	if (MetaWatchService.watchType == WatchType.DIGITAL)
-		    		Protocol.loadTemplate(0);
+		    		Protocol.loadTemplate(MetaWatchService.WatchBuffers.IDLE);
 
 		    	return true;
 			}
@@ -255,7 +255,7 @@ public class Test extends PreferenceActivity {
 		preferenceScreen.findPreference("update_display").setOnPreferenceClickListener(new OnPreferenceClickListener() {	
 			public boolean onPreferenceClick(Preference arg0) {
 		    	if (MetaWatchService.watchType == WatchType.DIGITAL)
-		    		Protocol.updateLcdDisplay(0);
+		    		Protocol.updateLcdDisplay(MetaWatchService.WatchBuffers.IDLE);
 		    	return true;
 			}
 		});


### PR DESCRIPTION
I'm not 100% sure if this patch is a good idea, but it seems to solve a problem I'm having.

Since flashing firmware 0.10.X on my watch, I started having issues with notifications disappearing more or less immediately after they were sent (while the watch was still vibrating). Some investigations showed that this was because MWM sometimes started the timeout countdown well before the notification actually was shown (probably because of sniff mode ), causing MWM to call Protocol.exitNotification() too early.

This patch waits for a mode change message from the watch before starting the timeout. Since I don't have an analog watch, I don't know if it sends a mode change message when it receives notifications, so this patch seriously needs analog testing. As I said, I'm not entirely sure that this patch is a good idea, but the limited testing I have done has been successful. Based on log output, the timeout seems to start quite instantly after the notification is shown. The question is if the notification system can lock up somehow, especially on the analog watch. I have tested quick series of notifications without issues.

I also cleaned up calls to Protocol.updateLcdDisplay(), replacing explicitly given parameters (like 0 or 2) with the already existing named constants MetaWatchService.WatchBuffers.*, mostly because I was thinking about a different way to fix the problem.
