### PR TITLE
Stop the Protocol and Notification senders on disconnection.

### DIFF
--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -877,6 +877,8 @@ public class MetaWatchService extends Service {
 	private void resetConnection() {
 		wakeLock.acquire(5000);
 		if (connectionState != ConnectionState.DISCONNECTING) {
+			Protocol.stopProtocolSender();
+			Notification.stopNotificationSender();
 			connectionState = ConnectionState.CONNECTING;
 			broadcastConnection(false);
 		}	

--- a/src/org/metawatch/manager/Notification.java
+++ b/src/org/metawatch/manager/Notification.java
@@ -201,6 +201,7 @@ public class Notification {
 
 					/* Wait until the watch shows the notification before starting the timeout. */
 					synchronized (Notification.modeChanged) {
+						// the timeout is here to avoid deadlocks, which we're trying to fix...
 						modeChanged.wait(30000);
 					}
 


### PR DESCRIPTION
This avoids a (temporary) deadlock in the notification sender, waiting for a mode change message when the watch restarts while receiving the notification (it happens). It's probably a good idea anyway. ;)
