### PR TITLE
More notification tweaks.

### DIFF
--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -765,9 +765,11 @@ public class MetaWatchService extends Service {
 					if (Preferences.logging) Log.d(MetaWatch.TAG,
 							"MetaWatchService.readFromDevice(): device type response; analog watch");
 
-					Idle.enableIdleKeys();
-					Idle.toIdle(this);
-					Idle.updateIdle(this, true);
+					if (watchState == WatchStates.OFF || watchState == WatchStates.IDLE) {
+						Idle.enableIdleKeys();
+						Idle.toIdle(this);
+						Idle.updateIdle(this, true);
+					}
 					
 					SharedPreferences sharedPreferences = PreferenceManager
 							.getDefaultSharedPreferences(context);
@@ -783,10 +785,13 @@ public class MetaWatchService extends Service {
 							"MetaWatchService.readFromDevice(): device type response; digital watch");
 
 					Protocol.configureMode();
-					Idle.enableIdleKeys();
-					Idle.toIdle(this);
-					Idle.updateIdle(this, true);
 
+					if (watchState == WatchStates.OFF || watchState == WatchStates.IDLE) {
+						Idle.enableIdleKeys();
+						Idle.toIdle(this);
+						Idle.updateIdle(this, true);
+					}
+					
 					SharedPreferences sharedPreferences = PreferenceManager
 							.getDefaultSharedPreferences(context);
 					boolean displaySplash = sharedPreferences.getBoolean("DisplaySplashScreen", true);

--- a/src/org/metawatch/manager/Notification.java
+++ b/src/org/metawatch/manager/Notification.java
@@ -74,11 +74,16 @@ public class Notification {
 			int currentNotificationPage = 0;
 			while (notificationSenderRunning) {
 				try {
-					currentNotification = null;
-					if(Preferences.showNotificationQueue)
-						MetaWatchService.notifyClients();
-					NotificationType notification = notificationQueue.take();
-					currentNotification = notification;
+					NotificationType notification;
+					if (currentNotification != null) {
+						// Something bad happened while showing the last notification, show it again.
+						notification = currentNotification;
+					} else {
+						if(Preferences.showNotificationQueue)
+							MetaWatchService.notifyClients();
+						notification = notificationQueue.take();
+						currentNotification = notification;
+					}
 					MetaWatchService.watchState = MetaWatchService.WatchStates.NOTIFICATION;
 					MetaWatchService.WatchModes.NOTIFICATION = true;
 					
@@ -262,6 +267,9 @@ public class Notification {
 						if (Preferences.logging) Log.d(MetaWatch.TAG,
 								"NotificationSender.run(): Done sleeping.");
 					}
+					
+					// We're done with this notification.
+					currentNotification = null;
 					
 					if (MetaWatchService.WatchModes.CALL == false) {
 						exitNotification(context);


### PR DESCRIPTION
Some more notification tweaks, not entirely related to the previous fixes.
- If a notification isn't finished showing when the notification sender is stopped (on a lost connection etc.), that notification is sent again when the sender restarts (only if MWM is kept running).
- Avoid overwriting notifications when receiving a Get Device Type Response from the watch.

As always, needs some analog testing. ;)
