### PR TITLE
Workaround for Galaxy S3 stock firmware pin problem

### DIFF
--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -504,7 +504,7 @@ public class MetaWatchService extends Service {
 					UUID uuid = UUID
 							.fromString("00001101-0000-1000-8000-00805F9B34FB");
 					bluetoothSocket = bluetoothDevice
-							.createRfcommSocketToServiceRecord(uuid);
+							.createInsecureRfcommSocketToServiceRecord(uuid);
 				}
 
 				bluetoothSocket.connect();


### PR DESCRIPTION
Hi benjymous,

I got a new phone (Galaxy S3). Metawatch is working, but the phone asks for a PIN everytime the link is disconnected. The solution I found so far is to use a insecure RFCOMM connection. I have just replaced the rfcomm socket creation by the insecure variant, as the watch is anyway using a fixed pin. So the authentication does not make sense that much. What do you think? Shall we add an option to allow insecure connections?

Bye

Matthias
