### PR TITLE
Forecast temperatures and condition icons are correct from Google

### DIFF
--- a/src/org/anddev/android/weatherforecast/weather/GoogleWeatherHandler.java
+++ b/src/org/anddev/android/weatherforecast/weather/GoogleWeatherHandler.java
@@ -119,7 +119,7 @@ public class GoogleWeatherHandler extends DefaultHandler {
 			}
 			// 'Inner' Tags within "<forecast_conditions>"
 			else if (localName.equals("low")) {
-				int temp = Integer.parseInt(dataAttribute);
+				float temp = Float.parseFloat(dataAttribute);
 				if (this.usingSITemperature) {
 					this.myWeatherSet.getLastWeatherForecastCondition()
 							.setTempMinCelsius(temp);
@@ -129,7 +129,7 @@ public class GoogleWeatherHandler extends DefaultHandler {
 									WeatherUtils.fahrenheitToCelsius(temp));
 				}
 			} else if (localName.equals("high")) {
-				int temp = Integer.parseInt(dataAttribute);
+				float temp = Float.parseFloat(dataAttribute);
 				if (this.usingSITemperature) {
 					this.myWeatherSet.getLastWeatherForecastCondition()
 							.setTempMaxCelsius(temp);

--- a/src/org/anddev/android/weatherforecast/weather/WeatherForecastCondition.java
+++ b/src/org/anddev/android/weatherforecast/weather/WeatherForecastCondition.java
@@ -11,8 +11,8 @@ public class WeatherForecastCondition {
 	// ===========================================================
 
 	private String dayofWeek = null;
-	private Integer tempMin = null;
-	private Integer tempMax = null;
+	private Float tempMin = null;
+	private Float tempMax = null;
 	private String iconURL = null;
 	private String condition = null;
 
@@ -36,19 +36,19 @@ public class WeatherForecastCondition {
 		this.dayofWeek = dayofWeek;
 	}
 
-	public Integer getTempMinCelsius() {
+	public Float getTempMinCelsius() {
 		return tempMin;
 	}
 
-	public void setTempMinCelsius(Integer tempMin) {
+	public void setTempMinCelsius(Float tempMin) {
 		this.tempMin = tempMin;
 	}
 
-	public Integer getTempMaxCelsius() {
+	public Float getTempMaxCelsius() {
 		return tempMax;
 	}
 
-	public void setTempMaxCelsius(Integer tempMax) {
+	public void setTempMaxCelsius(Float tempMax) {
 		this.tempMax = tempMax;
 	}
 

--- a/src/org/anddev/android/weatherforecast/weather/WeatherUtils.java
+++ b/src/org/anddev/android/weatherforecast/weather/WeatherUtils.java
@@ -3,11 +3,11 @@ package org.anddev.android.weatherforecast.weather;
 /** Useful Utility in working with temperatures. (conversions). */
 public class WeatherUtils {
 
-	public static int fahrenheitToCelsius(int tFahrenheit) {
-		return (int) ((5.0f / 9.0f) * (tFahrenheit - 32));
+	public static Float fahrenheitToCelsius(float tFahrenheit) {
+		return ((5.0f / 9.0f) * (tFahrenheit - 32));
 	}
 
-	public static int celsiusToFahrenheit(int tCelsius) {
-		return (int) ((9.0f / 5.0f) * tCelsius + 32);
+	public static Float celsiusToFahrenheit(float tCelsius) {
+		return ((9.0f / 5.0f) * tCelsius + 32);
 	}
 }

--- a/src/org/metawatch/manager/Monitors.java
+++ b/src/org/metawatch/manager/Monitors.java
@@ -387,7 +387,7 @@ public class Monitors {
 				WeatherData.forecast[i] = m.new Forecast();
 				WeatherData.forecast[i].day = null;
 				
-				WeatherData.forecast[i].icon = getIconGoogleWeather(wfc.getCondition());
+				WeatherData.forecast[i].icon = getIconGoogleWeather(wfc.getCondition().toLowerCase());
 				WeatherData.forecast[i].day = wfc.getDayofWeek();
 				
 				if (Preferences.weatherCelsius) {
@@ -397,11 +397,11 @@ public class Monitors {
 					WeatherData.forecast[i].tempHigh = 
 							  Integer.toString(WeatherUtils
 									.celsiusToFahrenheit(wfc
-											.getTempMaxCelsius()));
+											.getTempMaxCelsius()).intValue());
 					WeatherData.forecast[i].tempLow = 
 							  Integer.toString(WeatherUtils
 									.celsiusToFahrenheit(wfc
-											.getTempMinCelsius()));
+											.getTempMinCelsius()).intValue());
 				}
 			}
 			


### PR DESCRIPTION
When using Google for weather, the forecast temperatures are stored in Celsius. Their type is now Float so information is not lost when converting between Fahrenheit and Celsius. Also, the condition string is converted to lowercase so it can be found in the list of available icons.
