### PR TITLE
Yahoo Weather and some Google Weather fixes

### DIFF
--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -372,7 +372,7 @@
 				android:title="Weather Geolocation"
 				android:key="WeatherGeolocation"
 				android:summary="Use Geolocation for weather"
-				android:defaultValue="false"
+				android:defaultValue="true"
 				/>
 			<EditTextPreference
 				android:title="API Key"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -105,12 +105,14 @@
 	<item>Disabled</item>
     <item>Google Weather</item>
     <item>Weather Underground</item>
+    <item>Yahoo Weather</item>
     </string-array>
     
     <string-array name="settings_weather_provider_values"> 
 	<item>0</item>
 	<item>1</item>
 	<item>2</item>
+	<item>3</item>
 	</string-array>
     
     <string-array name="settings_app_launch_mode_name"> 

--- a/src/org/metawatch/manager/IntentReceiver.java
+++ b/src/org/metawatch/manager/IntentReceiver.java
@@ -38,7 +38,6 @@ import org.damazio.notifier.event.receivers.mms.EncodedStringValue;
 import org.damazio.notifier.event.receivers.mms.PduHeaders;
 import org.damazio.notifier.event.receivers.mms.PduParser;
 import org.metawatch.manager.MetaWatchService.Preferences;
-import org.metawatch.manager.Monitors.WeatherData;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -366,16 +365,16 @@ public class IntentReceiver extends BroadcastReceiver {
 			else {
 				if (Preferences.logging) Log.d(MetaWatch.TAG, "IntentReceiver.onReceive(): Data connectivity available.");
 				
-				long currentTime = System.currentTimeMillis();
-				long diff = currentTime - WeatherData.timeStamp;
-				
-				if (diff < 30 * 60*1000) {
-					if (Preferences.logging) Log.d(MetaWatch.TAG,
-							"Skipping weather update - updated less than 30m ago");
-				}
-				else {			
+//				long currentTime = System.currentTimeMillis();
+//				long diff = currentTime - WeatherData.timeStamp;
+//				
+//				if (diff < 30 * 60*1000) {
+//					if (Preferences.logging) Log.d(MetaWatch.TAG,
+//							"Skipping weather update - updated less than 30m ago");
+//				}
+//				else {			
 					Monitors.updateWeatherData(context);
-				}
+//				}
 			}
 
 			

--- a/src/org/metawatch/manager/MetaWatch.java
+++ b/src/org/metawatch/manager/MetaWatch.java
@@ -39,14 +39,11 @@ import java.io.InputStream;
 import org.metawatch.manager.MetaWatchService.Preferences;
 import org.metawatch.manager.MetaWatchService.WeatherProvider;
 import org.metawatch.manager.Monitors.LocationData;
-import org.metawatch.manager.Monitors.WeatherData;
-
-import com.bugsense.trace.BugSenseHandler;
 
 import android.app.ActivityManager;
+import android.app.ActivityManager.RunningServiceInfo;
 import android.app.AlertDialog;
 import android.app.TabActivity;
-import android.app.ActivityManager.RunningServiceInfo;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -70,6 +67,8 @@ import android.webkit.WebView;
 import android.widget.TabHost;
 import android.widget.TextView;
 import android.widget.ToggleButton;
+
+import com.bugsense.trace.BugSenseHandler;
 
 public class MetaWatch extends TabActivity {
    
@@ -295,12 +294,12 @@ public class MetaWatch extends TabActivity {
     	
     	if (Preferences.weatherProvider != WeatherProvider.DISABLED) {
     		textView.append("\n");
-    		if (WeatherData.received) {
+    		if (Monitors.weatherData.received) {
     			textView.append("Weather last updated:\n");
     			textView.append("  Forecast:\n    ");
-    			printDate(WeatherData.forecastTimeStamp);
+    			printDate(Monitors.weatherData.forecastTimeStamp);
     			textView.append("  Current Observation:\n    ");
-    			printDate(WeatherData.timeStamp);
+    			printDate(Monitors.weatherData.timeStamp);
     		}
     		else {
     			textView.append("Waiting for weather data.\n");

--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -173,7 +173,7 @@ public class MetaWatchService extends Service {
 		public static int weatherProvider = WeatherProvider.GOOGLE;
 		public static String weatherCity = "Dallas,US";
 		public static boolean weatherCelsius = false;
-		public static boolean weatherGeolocation = false;
+		public static boolean weatherGeolocation = true;
 		public static String wundergroundKey = "";
 		public static int fontSize = 2;
 		public static int smsLoopInterval = 15;
@@ -213,7 +213,7 @@ public class MetaWatchService extends Service {
 	public static void loadPreferences(Context context) {
 		SharedPreferences sharedPreferences = PreferenceManager
 				.getDefaultSharedPreferences(context);
-
+		
 		Preferences.logging = sharedPreferences.getBoolean("logging",
 				Preferences.logging);
 		Preferences.notifyCall = sharedPreferences.getBoolean("NotifyCall",

--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -129,6 +129,7 @@ public class MetaWatchService extends Service {
 		public static final int DISABLED = 0;
 		public static final int GOOGLE = 1;
 		public static final int WUNDERGROUND = 2;
+		public static final int YAHOO = 3;
 	}
 
 	final static class WatchModes {

--- a/src/org/metawatch/manager/Test.java
+++ b/src/org/metawatch/manager/Test.java
@@ -40,16 +40,15 @@ import java.util.Random;
 import org.metawatch.manager.MetaWatchService.Preferences;
 import org.metawatch.manager.MetaWatchService.WatchType;
 import org.metawatch.manager.Monitors.LocationData;
-import org.metawatch.manager.Monitors.WeatherData;
 import org.metawatch.manager.Notification.VibratePattern;
 
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Debug;
 import android.preference.Preference;
+import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceScreen;
-import android.preference.Preference.OnPreferenceClickListener;
 import android.util.Log;
 
 public class Test extends PreferenceActivity {
@@ -326,7 +325,7 @@ public class Test extends PreferenceActivity {
 		    	LocationData.longitude = (rnd.nextDouble()*360.0)-180.0;
 		    	LocationData.timeStamp = System.currentTimeMillis();	
 		    	LocationData.received = true;
-		    	WeatherData.timeStamp = 0;
+		    	Monitors.weatherData.timeStamp = 0;
 		    	Monitors.updateWeatherData(context);
 		    	return true;
 			}

--- a/src/org/metawatch/manager/actions/InternalActions.java
+++ b/src/org/metawatch/manager/actions/InternalActions.java
@@ -3,7 +3,6 @@ package org.metawatch.manager.actions;
 import org.metawatch.manager.Call;
 import org.metawatch.manager.MediaControl;
 import org.metawatch.manager.Monitors;
-import org.metawatch.manager.Monitors.WeatherData;
 import org.metawatch.manager.apps.InternalApp;
 
 import android.content.Context;
@@ -148,7 +147,7 @@ public class InternalActions {
 		}
 		
 		public String getName() {
-			return WeatherData.received 
+			return Monitors.weatherData.received 
 					? "Refresh Weather"
 					: "Refreshing...";
 		}
@@ -164,7 +163,7 @@ public class InternalActions {
 		}
 		
 		public long getTimestamp() {
-			return WeatherData.timeStamp;
+			return Monitors.weatherData.timeStamp;
 		}
 	}
 	

--- a/src/org/metawatch/manager/weather/AbstractWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/AbstractWeatherEngine.java
@@ -17,6 +17,7 @@ public abstract class AbstractWeatherEngine implements WeatherEngine {
 	 * @return True if weather data shall be updated
 	 */
 	public boolean isUpdateRequired(WeatherData data) {
+
 		if (data.timeStamp > 0 && data.received) {
 			long currentTime = System.currentTimeMillis();
 			long diff = currentTime - data.timeStamp;

--- a/src/org/metawatch/manager/weather/AbstractWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/AbstractWeatherEngine.java
@@ -1,0 +1,36 @@
+package org.metawatch.manager.weather;
+
+import org.metawatch.manager.MetaWatch;
+import org.metawatch.manager.MetaWatchService.Preferences;
+
+import android.util.Log;
+
+public abstract class AbstractWeatherEngine implements WeatherEngine {
+
+	private final static int TIME_FIVE_MINUTES = 5 * 60 * 1000;
+
+	/**
+	 * Weather update is done frequently. Update rate can be configured here.
+	 * 
+	 * @param data
+	 *            Weather data
+	 * @return True if weather data shall be updated
+	 */
+	public boolean isUpdateRequired(WeatherData data) {
+		if (data.timeStamp > 0 && data.received) {
+			long currentTime = System.currentTimeMillis();
+			long diff = currentTime - data.timeStamp;
+
+			if (diff < TIME_FIVE_MINUTES) {
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG,
+							"Skipping weather update - updated less than 5m ago");
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+}

--- a/src/org/metawatch/manager/weather/Forecast.java
+++ b/src/org/metawatch/manager/weather/Forecast.java
@@ -1,0 +1,58 @@
+package org.metawatch.manager.weather;
+
+public class Forecast {
+
+	private String day;
+	private String icon;
+	private String tempHigh;
+	private String tempLow;
+
+	public String getDay() {
+		return day;
+	}
+
+	public void setDay(String day) {
+		this.day = day;
+	}
+
+	public String getIcon() {
+		return icon;
+	}
+
+	public void setIcon(String icon) {
+		this.icon = icon;
+	}
+
+	public String getTempHigh() {
+		return tempHigh;
+	}
+
+	public void setTempHigh(String tempHigh) {
+		this.tempHigh = tempHigh;
+	}
+
+	public String getTempLow() {
+		return tempLow;
+	}
+
+	public void setTempLow(String tempLow) {
+		this.tempLow = tempLow;
+	}
+
+	public void setTempHigh(Float tempHigh) {
+		// Not much space on the display, so we use the
+		// integer part of the float only.
+		setTempHigh("" + tempHigh.intValue());
+	}
+
+	public void setTempLow(Float tempLow) {
+		setTempLow("" + tempLow.intValue());
+	}
+
+	@Override
+	public String toString() {
+		return "Forecast [day=" + getDay() + ", icon=" + getIcon()
+				+ ", tempHigh=" + getTempHigh() + ", tempLow=" + getTempLow()
+				+ "]";
+	}
+}

--- a/src/org/metawatch/manager/weather/GoogleWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/GoogleWeatherEngine.java
@@ -96,6 +96,8 @@ public class GoogleWeatherEngine extends AbstractWeatherEngine {
 						if (Preferences.logging)
 							Log.e(MetaWatch.TAG,
 									"Exception while retreiving postalcode", e);
+						PostalCode = "";
+						locality = "UNKNOWN";
 					}
 
 					if (PostalCode.equals("")) {

--- a/src/org/metawatch/manager/weather/GoogleWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/GoogleWeatherEngine.java
@@ -1,10 +1,7 @@
 package org.metawatch.manager.weather;
 
-import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -29,8 +26,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 
 import android.content.Context;
-import android.location.Address;
-import android.location.Geocoder;
 import android.util.Log;
 
 public class GoogleWeatherEngine extends AbstractWeatherEngine {
@@ -69,46 +64,9 @@ public class GoogleWeatherEngine extends AbstractWeatherEngine {
 							"Monitors.updateWeatherDataGoogle(): start");
 				
 				String queryString;
-				if (Preferences.weatherGeolocation && LocationData.received) {
-					Geocoder geocoder;
-					String locality = "";
-					String PostalCode = "";
-
-					try {
-						geocoder = new Geocoder(context, Locale.getDefault());
-						List<Address> addresses = geocoder.getFromLocation(
-								LocationData.latitude, LocationData.longitude,
-								1);
-
-						for (Address address : addresses) {
-							if (!address.getPostalCode().equalsIgnoreCase("")) {
-								PostalCode = address.getPostalCode();
-								locality = address.getLocality();
-								if (locality.equals("")) {
-									locality = PostalCode;
-								} else {
-									PostalCode = locality + ", " + PostalCode;
-								}
-
-							}
-						}
-					} catch (IOException e) {
-						if (Preferences.logging)
-							Log.e(MetaWatch.TAG,
-									"Exception while retreiving postalcode", e);
-						PostalCode = "";
-						locality = "UNKNOWN";
-					}
-
-					if (PostalCode.equals("")) {
-						PostalCode = Preferences.weatherCity;
-					}
-					if (locality.equals("")) {
-						weatherData.locationName = PostalCode;
-					} else {
-						weatherData.locationName = locality;
-					}
-
+				if (isGeolocationDataUsed()) {
+					GoogleGeoCoderLocationData locationData = reverseLookupGeoLocation(context, LocationData.latitude, LocationData.longitude);
+					weatherData.locationName = locationData.getLocationName();
 					long lat = (long) (LocationData.latitude * 1000000);
 					long lon = (long) (LocationData.longitude * 1000000);
 					queryString = "http://www.google.com/ig/api?weather=,,,"
@@ -214,4 +172,6 @@ public class GoogleWeatherEngine extends AbstractWeatherEngine {
 
 		return weatherData;
 	}
+
+	
 }

--- a/src/org/metawatch/manager/weather/GoogleWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/GoogleWeatherEngine.java
@@ -1,0 +1,215 @@
+package org.metawatch.manager.weather;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.anddev.android.weatherforecast.weather.GoogleWeatherHandler;
+import org.anddev.android.weatherforecast.weather.WeatherCurrentCondition;
+import org.anddev.android.weatherforecast.weather.WeatherForecastCondition;
+import org.anddev.android.weatherforecast.weather.WeatherSet;
+import org.anddev.android.weatherforecast.weather.WeatherUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.metawatch.manager.Idle;
+import org.metawatch.manager.MetaWatch;
+import org.metawatch.manager.MetaWatchService;
+import org.metawatch.manager.MetaWatchService.Preferences;
+import org.metawatch.manager.Monitors.LocationData;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+import android.content.Context;
+import android.location.Address;
+import android.location.Geocoder;
+import android.util.Log;
+
+public class GoogleWeatherEngine extends AbstractWeatherEngine {
+
+	public String getIcon(String cond) {
+		if (cond.equals("clear") || cond.equals("sunny"))
+			return "weather_sunny.bmp";
+		else if (cond.equals("cloudy") || cond.equals("overcast"))
+			return "weather_cloudy.bmp";
+		else if (cond.equals("mostly cloudy") || cond.equals("partly cloudy")
+				|| cond.equals("mostly sunny") || cond.equals("partly sunny"))
+			return "weather_partlycloudy.bmp";
+		else if (cond.equals("light rain") || cond.equals("rain")
+				|| cond.equals("rain showers") || cond.equals("showers")
+				|| cond.equals("chance of showers")
+				|| cond.equals("scattered showers")
+				|| cond.equals("freezing rain")
+				|| cond.equals("freezing drizzle")
+				|| cond.equals("rain and snow"))
+			return "weather_rain.bmp";
+		else if (cond.equals("thunderstorm") || cond.equals("chance of storm")
+				|| cond.equals("isolated thunderstorms"))
+			return "weather_thunderstorm.bmp";
+		else if (cond.equals("chance of snow") || cond.equals("snow showers")
+				|| cond.equals("ice/snow") || cond.equals("flurries"))
+			return "weather_snow.bmp";
+		else
+			return "weather_cloudy.bmp";
+	}
+
+	public synchronized WeatherData update(Context context, WeatherData weatherData) {
+		try {
+			if (isUpdateRequired(weatherData)) {
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG,
+							"Monitors.updateWeatherDataGoogle(): start");
+				
+				String queryString;
+				if (Preferences.weatherGeolocation && LocationData.received) {
+					Geocoder geocoder;
+					String locality = "";
+					String PostalCode = "";
+
+					try {
+						geocoder = new Geocoder(context, Locale.getDefault());
+						List<Address> addresses = geocoder.getFromLocation(
+								LocationData.latitude, LocationData.longitude,
+								1);
+
+						for (Address address : addresses) {
+							if (!address.getPostalCode().equalsIgnoreCase("")) {
+								PostalCode = address.getPostalCode();
+								locality = address.getLocality();
+								if (locality.equals("")) {
+									locality = PostalCode;
+								} else {
+									PostalCode = locality + ", " + PostalCode;
+								}
+
+							}
+						}
+					} catch (IOException e) {
+						if (Preferences.logging)
+							Log.e(MetaWatch.TAG,
+									"Exception while retreiving postalcode", e);
+					}
+
+					if (PostalCode.equals("")) {
+						PostalCode = Preferences.weatherCity;
+					}
+					if (locality.equals("")) {
+						weatherData.locationName = PostalCode;
+					} else {
+						weatherData.locationName = locality;
+					}
+
+					long lat = (long) (LocationData.latitude * 1000000);
+					long lon = (long) (LocationData.longitude * 1000000);
+					queryString = "http://www.google.com/ig/api?weather=,,,"
+							+ lat + "," + lon;
+				} else {
+					queryString = "http://www.google.com/ig/api?weather="
+							+ Preferences.weatherCity;
+					weatherData.locationName = Preferences.weatherCity;
+				}
+
+				HttpClient hc = new DefaultHttpClient();
+				HttpGet httpGet = new HttpGet(queryString);
+				HttpResponse rp = hc.execute(httpGet);
+
+				if (rp.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+					String s = EntityUtils.toString(rp.getEntity());
+					if (Preferences.logging)
+						Log.d(MetaWatch.TAG, "Got weather data " + s);
+
+					SAXParserFactory spf = SAXParserFactory.newInstance();
+					SAXParser sp = spf.newSAXParser();
+					XMLReader xr = sp.getXMLReader();
+
+					GoogleWeatherHandler gwh = new GoogleWeatherHandler();
+					xr.setContentHandler(gwh);
+					xr.parse(new InputSource(new StringReader(s)));
+					WeatherSet ws = gwh.getWeatherSet();
+					if (ws == null || ws.getWeatherCurrentCondition() == null) {
+						if (Preferences.logging)
+							Log.e(MetaWatch.TAG,
+									"Google Weather API did not respond with valid data: "
+											+ s);
+					} else {
+						WeatherCurrentCondition wcc = ws
+								.getWeatherCurrentCondition();
+
+						ArrayList<WeatherForecastCondition> conditions = ws
+								.getWeatherForecastConditions();
+
+						int days = conditions.size();
+						weatherData.forecast = new Forecast[days];
+
+						for (int i = 0; i < days; ++i) {
+							WeatherForecastCondition wfc = conditions.get(i);
+
+							weatherData.forecast[i] = new Forecast();
+							weatherData.forecast[i].setDay(wfc.getDayofWeek());
+							weatherData.forecast[i].setIcon(getIcon(wfc
+									.getCondition().toLowerCase()));
+
+							if (Preferences.weatherCelsius) {
+								weatherData.forecast[i].setTempHigh(wfc
+										.getTempMaxCelsius());
+								weatherData.forecast[i].setTempLow(wfc
+										.getTempMinCelsius());
+							} else {
+								weatherData.forecast[i]
+										.setTempHigh(WeatherUtils
+												.celsiusToFahrenheit(wfc
+														.getTempMaxCelsius()));
+								weatherData.forecast[i].setTempLow(WeatherUtils
+										.celsiusToFahrenheit(wfc
+												.getTempMinCelsius()));
+							}
+
+							if (Preferences.logging)
+								Log.d(MetaWatch.TAG, "Forecast #" + i + ": "
+										+ weatherData.forecast[i]);
+						}
+
+						weatherData.celsius = Preferences.weatherCelsius;
+
+						String cond = wcc.getCondition();
+						weatherData.condition = cond;
+
+						if (Preferences.weatherCelsius) {
+							weatherData.temp = Integer.toString(wcc
+									.getTempCelcius());
+						} else {
+							weatherData.temp = Integer.toString(wcc
+									.getTempFahrenheit());
+						}
+
+						cond = cond.toLowerCase();
+
+						weatherData.icon = getIcon(cond);
+						weatherData.received = true;
+						weatherData.timeStamp = System.currentTimeMillis();
+
+						Idle.updateIdle(context, true);
+						MetaWatchService.notifyClients();
+					}
+				}
+			}
+
+		} catch (Exception e) {
+			if (Preferences.logging)
+				Log.e(MetaWatch.TAG, "Exception while retreiving weather", e);
+		} finally {
+			if (Preferences.logging)
+				Log.d(MetaWatch.TAG, "Monitors.updateWeatherData(): finish");
+		}
+
+		return weatherData;
+	}
+}

--- a/src/org/metawatch/manager/weather/WeatherData.java
+++ b/src/org/metawatch/manager/weather/WeatherData.java
@@ -1,0 +1,24 @@
+package org.metawatch.manager.weather;
+
+public class WeatherData {
+	public boolean received = false;
+	public String icon;
+	public String temp;
+	public String condition;
+	public String locationName;
+	public boolean celsius = false;
+
+	public int sunriseH = 7;
+	public int sunriseM = 0;
+
+	public int sunsetH = 19;
+	public int sunsetM = 0;
+
+	public int moonPercentIlluminated = -1;
+	public int ageOfMoon = -1;
+
+	public Forecast[] forecast = null;
+
+	public long timeStamp = 0;
+	public long forecastTimeStamp = 0;
+}

--- a/src/org/metawatch/manager/weather/WeatherData.java
+++ b/src/org/metawatch/manager/weather/WeatherData.java
@@ -1,5 +1,7 @@
 package org.metawatch.manager.weather;
 
+import java.util.Arrays;
+
 public class WeatherData {
 	public boolean received = false;
 	public String icon;
@@ -21,4 +23,18 @@ public class WeatherData {
 
 	public long timeStamp = 0;
 	public long forecastTimeStamp = 0;
+	@Override
+	public String toString() {
+		return "WeatherData [received=" + received + ", icon=" + icon
+				+ ", temp=" + temp + ", condition=" + condition
+				+ ", locationName=" + locationName + ", celsius=" + celsius
+				+ ", sunriseH=" + sunriseH + ", sunriseM=" + sunriseM
+				+ ", sunsetH=" + sunsetH + ", sunsetM=" + sunsetM
+				+ ", moonPercentIlluminated=" + moonPercentIlluminated
+				+ ", ageOfMoon=" + ageOfMoon + ", forecast="
+				+ Arrays.toString(forecast) + ", timeStamp=" + timeStamp
+				+ ", forecastTimeStamp=" + forecastTimeStamp + "]";
+	}
+	
+	
 }

--- a/src/org/metawatch/manager/weather/WeatherEngine.java
+++ b/src/org/metawatch/manager/weather/WeatherEngine.java
@@ -1,0 +1,13 @@
+package org.metawatch.manager.weather;
+
+import android.content.Context;
+
+/**
+ * Weather provider interface for different weather APIs (e.g. Wunderweather,
+ * Google, etc.)
+ */
+public interface WeatherEngine {
+
+	WeatherData update(Context context, WeatherData data);
+
+}

--- a/src/org/metawatch/manager/weather/WeatherEngineFactory.java
+++ b/src/org/metawatch/manager/weather/WeatherEngineFactory.java
@@ -1,0 +1,42 @@
+package org.metawatch.manager.weather;
+
+import org.metawatch.manager.MetaWatch;
+import org.metawatch.manager.MetaWatchService.Preferences;
+import org.metawatch.manager.MetaWatchService.WeatherProvider;
+
+import android.util.Log;
+
+public class WeatherEngineFactory {
+
+	private static int currentEngineId = -1;
+	private static WeatherEngine currentEngine = null;
+
+	private static WeatherEngine createEngine() {
+		int engineId = Preferences.weatherProvider;
+		switch (engineId) {
+		case WeatherProvider.GOOGLE:
+			return new GoogleWeatherEngine();
+
+		case WeatherProvider.WUNDERGROUND:
+			return new WunderWeatherEngine();
+
+		default:
+			throw new IllegalArgumentException("Unknown weather engineId: "
+					+ engineId);
+		}
+	}
+
+	public static synchronized WeatherEngine getEngine() {
+		int engineId = Preferences.weatherProvider;
+		if (currentEngine == null || engineId != currentEngineId) {
+			if (Preferences.logging)
+				Log.d(MetaWatch.TAG, "Creating new weather engine with id "
+						+ engineId);
+
+			currentEngineId = engineId;
+			currentEngine = createEngine();
+		}
+		return currentEngine;
+	}
+
+}

--- a/src/org/metawatch/manager/weather/WeatherEngineFactory.java
+++ b/src/org/metawatch/manager/weather/WeatherEngineFactory.java
@@ -19,6 +19,9 @@ public class WeatherEngineFactory {
 
 		case WeatherProvider.WUNDERGROUND:
 			return new WunderWeatherEngine();
+			
+		case WeatherProvider.YAHOO:
+			return new YahooWeatherEngine();
 
 		default:
 			throw new IllegalArgumentException("Unknown weather engineId: "

--- a/src/org/metawatch/manager/weather/WunderWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/WunderWeatherEngine.java
@@ -52,7 +52,7 @@ public class WunderWeatherEngine extends AbstractWeatherEngine {
 			return "weather_cloudy.bmp";
 	}
 
-	public WeatherData update(Context context, WeatherData weatherData) {
+	public synchronized WeatherData update(Context context, WeatherData weatherData) {
 		try {
 			if (isUpdateRequired(weatherData)) {
 

--- a/src/org/metawatch/manager/weather/WunderWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/WunderWeatherEngine.java
@@ -1,0 +1,264 @@
+package org.metawatch.manager.weather;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Date;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.metawatch.manager.Idle;
+import org.metawatch.manager.MetaWatch;
+import org.metawatch.manager.MetaWatchService;
+import org.metawatch.manager.MetaWatchService.Preferences;
+import org.metawatch.manager.Monitors.LocationData;
+
+import android.content.Context;
+import android.util.Log;
+
+public class WunderWeatherEngine extends AbstractWeatherEngine {
+
+	public String getIcon(String cond, boolean isDay) {
+		if (cond.equals("clear") || cond.equals("sunny"))
+			if (isDay)
+				return "weather_sunny.bmp";
+			else
+				return "weather_nt_clear.bmp";
+		else if (cond.equals("cloudy"))
+			return "weather_cloudy.bmp";
+		else if (cond.equals("partlycloudy") || cond.equals("mostlycloudy")
+				|| cond.equals("partlysunny") || cond.equals("mostlysunny"))
+			if (isDay)
+				return "weather_partlycloudy.bmp";
+			else
+				return "weather_nt_partlycloudy.bmp";
+		else if (cond.equals("rain") || cond.equals("chancerain"))
+			return "weather_rain.bmp";
+		else if (cond.equals("fog") || cond.equals("hazy"))
+			return "weather_fog.bmp";
+		else if (cond.equals("tstorms") || cond.equals("chancetstorms"))
+			return "weather_thunderstorm.bmp";
+		else if (cond.equals("snow") || cond.equals("chancesnow")
+				|| cond.equals("sleet") || cond.equals("chancesleet")
+				|| cond.equals("flurries") || cond.equals("chanceflurries"))
+			return "weather_snow.bmp";
+		else
+			return "weather_cloudy.bmp";
+	}
+
+	public WeatherData update(Context context, WeatherData weatherData) {
+		try {
+			if (isUpdateRequired(weatherData)) {
+
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG,
+							"Monitors.updateWeatherDataWunderground(): start");
+
+				if ((LocationData.received || (Preferences.weatherGeolocation == false))
+						&& Preferences.wundergroundKey != "") {
+
+					String weatherLocation = Double
+							.toString(LocationData.latitude)
+							+ ","
+							+ Double.toString(LocationData.longitude);
+					if (Preferences.weatherGeolocation == false)
+						weatherLocation = Preferences.weatherCity.replace(",",
+								"").replace(" ", "%20");
+
+					String forecastQuery = "";
+					boolean hasForecast = false;
+
+					long diff = System.currentTimeMillis()
+							- weatherData.forecastTimeStamp;
+					if (weatherData.forecast == null
+							|| (diff > 3 * 60 * 60 * 1000)) {
+						// Only update forecast every three hours
+						forecastQuery = "forecast10day/astronomy/";
+						hasForecast = true;
+					}
+
+					String requestUrl = "http://api.wunderground.com/api/"
+							+ Preferences.wundergroundKey
+							+ "/geolookup/conditions/" + forecastQuery + "q/"
+							+ weatherLocation + ".json";
+
+					if (Preferences.logging)
+						Log.d(MetaWatch.TAG, "Request: " + requestUrl);
+
+					JSONObject json = getJSONfromURL(requestUrl);
+
+					JSONObject location = json.getJSONObject("location");
+					JSONObject current = json
+							.getJSONObject("current_observation");
+
+					if (hasForecast) {
+						JSONObject moon = json.getJSONObject("moon_phase");
+						JSONObject sunrise = moon.getJSONObject("sunrise");
+						weatherData.sunriseH = sunrise.getInt("hour");
+						weatherData.sunriseM = sunrise.getInt("minute");
+						JSONObject sunset = moon.getJSONObject("sunset");
+						weatherData.sunsetH = sunset.getInt("hour");
+						weatherData.sunsetM = sunset.getInt("minute");
+
+						weatherData.moonPercentIlluminated = moon
+								.getInt("percentIlluminated");
+						weatherData.ageOfMoon = moon.getInt("ageOfMoon");
+					}
+
+					boolean isDay = true;
+
+					Date dt = new Date();
+					int hours = dt.getHours();
+					int minutes = dt.getMinutes();
+
+					if ((hours < weatherData.sunriseH)
+							|| (hours == weatherData.sunriseH && minutes < weatherData.sunriseM)
+							|| (hours > weatherData.sunsetH)
+							|| (hours == weatherData.sunsetH && minutes > weatherData.sunsetM)) {
+						isDay = false;
+					}
+
+					weatherData.locationName = location.getString("city");
+					weatherData.condition = current.getString("weather");
+					weatherData.icon = getIcon(current.getString("icon"), isDay);
+
+					if (Preferences.weatherCelsius) {
+						weatherData.temp = current.getString("temp_c");
+					} else {
+						weatherData.temp = current.getString("temp_f");
+					}
+
+					if (hasForecast) {
+						JSONObject forecast = json.getJSONObject("forecast");
+						JSONArray forecastday = forecast.getJSONObject(
+								"simpleforecast").getJSONArray("forecastday");
+
+						int days = forecastday.length();
+						weatherData.forecast = new Forecast[days];
+
+						for (int i = 0; i < days; ++i) {
+							weatherData.forecast[i] = new Forecast();
+							JSONObject day = forecastday.getJSONObject(i);
+							JSONObject date = day.getJSONObject("date");
+
+							weatherData.forecast[i].setIcon(getIcon(
+									day.getString("icon"), true));
+							weatherData.forecast[i].setDay(date
+									.getString("weekday_short"));
+							if (Preferences.weatherCelsius) {
+								weatherData.forecast[i].setTempLow(day
+										.getJSONObject("low").getString(
+												"celsius"));
+								weatherData.forecast[i].setTempHigh(day
+										.getJSONObject("high").getString(
+												"celsius"));
+							} else {
+								weatherData.forecast[i].setTempLow(day
+										.getJSONObject("low").getString(
+												"fahrenheit"));
+								weatherData.forecast[i].setTempHigh(day
+										.getJSONObject("high").getString(
+												"fahrenheit"));
+							}
+						}
+
+						weatherData.forecastTimeStamp = System
+								.currentTimeMillis();
+					}
+
+					weatherData.celsius = Preferences.weatherCelsius;
+
+					weatherData.received = true;
+					weatherData.timeStamp = System.currentTimeMillis();
+
+					Idle.updateIdle(context, true);
+					MetaWatchService.notifyClients();
+				}
+
+			}
+
+		} catch (Exception e) {
+			if (Preferences.logging)
+				Log.e(MetaWatch.TAG, "Exception while retreiving weather", e);
+		} finally {
+			if (Preferences.logging)
+				Log.d(MetaWatch.TAG, "Monitors.updateWeatherData(): finish");
+		}
+
+		return weatherData;
+	}
+
+	// http://p-xr.com/android-tutorial-how-to-parse-read-json-data-into-a-android-listview/
+	public static JSONObject getJSONfromURL(String url) {
+
+		// initialize
+		InputStream is = null;
+		String result = "";
+		JSONObject jArray = null;
+
+		// http post
+		try {
+			HttpClient httpclient = new DefaultHttpClient();
+			HttpPost httppost = new HttpPost(url);
+			HttpResponse response = httpclient.execute(httppost);
+			HttpEntity entity = response.getEntity();
+			is = entity.getContent();
+
+		} catch (Exception e) {
+			if (Preferences.logging)
+				Log.e(MetaWatch.TAG, "Error in http connection " + e.toString());
+		}
+
+		// convert response to string
+		if (is != null) {
+			try {
+				BufferedReader reader = new BufferedReader(
+						new InputStreamReader(is, "iso-8859-1"), 8);
+				StringBuilder sb = new StringBuilder();
+				String line = null;
+				while ((line = reader.readLine()) != null) {
+					sb.append(line + "\n");
+				}
+				is.close();
+				result = sb.toString();
+			} catch (Exception e) {
+				if (Preferences.logging)
+					Log.e(MetaWatch.TAG,
+							"Error converting result " + e.toString());
+			}
+
+			// // dump to sdcard for debugging
+			// File sdCard = Environment.getExternalStorageDirectory();
+			// File file = new File(sdCard, "weather.json");
+			//
+			// try {
+			// FileWriter writer = new FileWriter(file);
+			// writer.append(result);
+			// writer.flush();
+			// writer.close();
+			// } catch (FileNotFoundException e1) {
+			// // TODO Auto-generated catch block
+			// e1.printStackTrace();
+			// } catch (IOException e) {
+			// // TODO Auto-generated catch block
+			// e.printStackTrace();
+			// }
+
+			// try parse the string to a JSON object
+			try {
+				jArray = new JSONObject(result);
+			} catch (JSONException e) {
+				if (Preferences.logging)
+					Log.e(MetaWatch.TAG, "Error parsing data " + e.toString());
+			}
+		}
+		return jArray;
+	}
+
+}

--- a/src/org/metawatch/manager/weather/YahooWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/YahooWeatherEngine.java
@@ -2,7 +2,9 @@ package org.metawatch.manager.weather;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -138,16 +140,21 @@ public class YahooWeatherEngine extends AbstractWeatherEngine {
 					Log.d(MetaWatch.TAG,
 							"Monitors.updateWeatherDataYahoo(): start");
 
+				// http://developer.yahoo.com/geo/placefinder/guide/requests.html#gflags-parameter
+				// The problem is when we do not use the "gflags=R" argument, we
+				// don't always get a WOEID
+				String arguments = "&count=1&gflags=R";
+
 				String placeFinderUrl = null;
 				if (Preferences.weatherGeolocation && LocationData.received) {
 					placeFinderUrl = "http://where.yahooapis.com/geocode?q="
 							+ LocationData.latitude + ","
-							+ LocationData.longitude + "&gflags=R";
+							+ LocationData.longitude + arguments;
 				} else {
 					String weatherLocation = Preferences.weatherCity.replace(
 							" ", "%20");
 					placeFinderUrl = "http://where.yahooapis.com/geocode?q="
-							+ weatherLocation;
+							+ weatherLocation + arguments;
 				}
 
 				return requestWeatherFromYahooPlacefinder(placeFinderUrl,
@@ -198,6 +205,11 @@ public class YahooWeatherEngine extends AbstractWeatherEngine {
 				weatherData.locationName = city;
 				// else
 				// weatherData.locationName = Preferences.weatherCity;
+
+				// DEBUG - WILL BE REMOVED AFTER SOME TEST PERIOD
+				String tt = new SimpleDateFormat("hh:mm").format(new Date());
+				weatherData.locationName = tt + " " + city;
+				// DEBUG
 
 				if (Preferences.logging)
 					Log.d(MetaWatch.TAG, "Got WOEID: " + woeId + " and CITY: "
@@ -351,8 +363,9 @@ public class YahooWeatherEngine extends AbstractWeatherEngine {
 				code = parseCode(attributes.getValue("code"));
 				temp = attributes.getValue("temp");
 
-				Log.d(MetaWatch.TAG, "Weather Condition " + text + " " + code
-						+ " " + temp);
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG, "Weather Condition " + text + " "
+							+ code + " " + temp);
 
 			} else if (localName.equals("forecast")) {
 				// <yweather:forecast day="Wed" date="11 Jul 2012" low="55"

--- a/src/org/metawatch/manager/weather/YahooWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/YahooWeatherEngine.java
@@ -146,7 +146,7 @@ public class YahooWeatherEngine extends AbstractWeatherEngine {
 				String arguments = "&count=1&gflags=R";
 
 				String placeFinderUrl = null;
-				if (Preferences.weatherGeolocation && LocationData.received) {
+				if (isGeolocationDataUsed()) {
 					placeFinderUrl = "http://where.yahooapis.com/geocode?q="
 							+ LocationData.latitude + ","
 							+ LocationData.longitude + arguments;
@@ -207,8 +207,8 @@ public class YahooWeatherEngine extends AbstractWeatherEngine {
 				// weatherData.locationName = Preferences.weatherCity;
 
 				// DEBUG - WILL BE REMOVED AFTER SOME TEST PERIOD
-				String tt = new SimpleDateFormat("hh:mm").format(new Date());
-				weatherData.locationName = tt + " " + city;
+				// String tt = new SimpleDateFormat("hh:mm").format(new Date());
+				// weatherData.locationName = tt + " " + city;
 				// DEBUG
 
 				if (Preferences.logging)

--- a/src/org/metawatch/manager/weather/YahooWeatherEngine.java
+++ b/src/org/metawatch/manager/weather/YahooWeatherEngine.java
@@ -1,0 +1,360 @@
+package org.metawatch.manager.weather;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.metawatch.manager.MetaWatch;
+import org.metawatch.manager.MetaWatchService.Preferences;
+import org.metawatch.manager.Monitors.LocationData;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+import android.content.Context;
+import android.util.Log;
+
+public class YahooWeatherEngine extends AbstractWeatherEngine {
+
+	public String getIcon(int code) {
+		// http://developer.yahoo.com/weather/
+
+		/*
+		 * 0 tornado 1 tropical storm 2 hurricane 3 severe thunderstorms 4
+		 * thunderstorms 5 mixed rain and snow 6 mixed rain and sleet 7 mixed
+		 * snow and sleet 8 freezing drizzle 9 drizzle 10 freezing rain 11
+		 * showers 12 showers 13 snow flurries 14 light snow showers 15 blowing
+		 * snow 16 snow 17 hail 18 sleet 19 dust 20 foggy 21 haze 22 smoky 23
+		 * blustery 24 windy 25 cold 26 cloudy 27 mostly cloudy (night) 28
+		 * mostly cloudy (day) 29 partly cloudy (night) 30 partly cloudy (day)
+		 * 31 clear (night) 32 sunny 33 fair (night) 34 fair (day) 35 mixed rain
+		 * and hail 36 hot 37 isolated thunderstorms 38 scattered thunderstorms
+		 * 39 scattered thunderstorms 40 scattered showers 41 heavy snow 42
+		 * scattered snow showers 43 heavy snow 44 partly cloudy 45
+		 * thundershowers 46 snow showers 47 isolated thundershowers 3200 not
+		 * available
+		 */
+
+		switch (code) {
+		case 0:
+		case 1:
+		case 2:
+		case 3:
+		case 4:
+			return "weather_thunderstorm.bmp";
+
+		case 5:
+		case 6:
+		case 7:
+		case 8:
+			return "weather_snow.bmp";
+
+		case 9:
+		case 10:
+		case 11:
+		case 12:
+			return "weather_rain.bmp";
+
+		case 13:
+		case 14:
+		case 15:
+		case 16:
+		case 17:
+		case 18:
+			return "weather_snow.bmp";
+
+		case 19:
+		case 20:
+		case 21:
+		case 22:
+			return "weather_fog.bmp";
+
+		case 23:
+		case 24:
+		case 25:
+		case 26:
+			return "weather_cloudy.bmp";
+		case 27:
+			return "weather_nt_partlycloudy.bmp";
+		case 28:
+			return "weather_cloudy.bmp";
+		case 29:
+			return "weather_nt_partlycloudy.bmp";
+		case 30:
+			return "weather_partlycloudy.bmp";
+		case 31:
+			return "weather_nt_clear.bmp";
+		case 32:
+			return "weather_sunny.bmp";
+		case 33:
+			return "weather_nt_clear.bmp";
+		case 34:
+			return "weather_sunny.bmp";
+		case 35:
+			return "weather_rain.bmp";
+		case 36:
+			return "weather_sunny.bmp";
+		case 37:
+		case 38:
+		case 39:
+			return "weather_thunderstorm.bmp";
+		case 40:
+			return "weather_rain.bmp";
+		case 41:
+		case 42:
+		case 43:
+			return "weather_snow.bmp";
+		case 44:
+			return "weather_partlycloudy.bmp";
+		case 45:
+			return "weather_thunderstorm.bmp";
+		case 46:
+			return "weather_snow.bmp";
+		case 47:
+			return "weather_thunderstorm.bmp";
+		default:
+			return "weather_cloudy.bmp";// Default in other impls so far
+		}
+	}
+
+	public synchronized WeatherData update(Context context,
+			WeatherData weatherData) {
+		try {
+			if (isUpdateRequired(weatherData)) {
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG,
+							"Monitors.updateWeatherDataGoogle(): start");
+
+				if (Preferences.weatherGeolocation && LocationData.received) {
+					requestWeatherFromGeoLocation(LocationData.latitude,
+							LocationData.longitude, weatherData);
+				}
+			}
+
+		} catch (Exception e) {
+			if (Preferences.logging)
+				Log.e(MetaWatch.TAG, "Exception while retreiving weather", e);
+		} finally {
+			if (Preferences.logging)
+				Log.d(MetaWatch.TAG, "Monitors.updateWeatherData(): finish");
+		}
+
+		return weatherData;
+	}
+
+	private WeatherData requestWeatherFromGeoLocation(double latitude,
+			double longitude, WeatherData weatherData) throws IOException {
+		try {
+			// Ask Yahoo Placefinder to search the WOEID.
+			HttpClient hc = new DefaultHttpClient();
+			HttpGet httpGet = new HttpGet(
+					"http://where.yahooapis.com/geocode?q="
+							+ LocationData.latitude + ","
+							+ LocationData.longitude + "&gflags=R");
+			HttpResponse rp = hc.execute(httpGet);
+			if (rp.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+				SAXParserFactory spf = SAXParserFactory.newInstance();
+				SAXParser sp = spf.newSAXParser();
+				XMLReader xr = sp.getXMLReader();
+
+				String s = EntityUtils.toString(rp.getEntity());
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG, "Got placefinder response " + s);
+
+				YahooPlacefinderHandler handler = new YahooPlacefinderHandler();
+				xr.setContentHandler(handler);
+				xr.parse(new InputSource(new StringReader(s)));
+				String woeId = handler.getWoeId();
+				String city = handler.getCity();
+
+				weatherData.locationName = city;
+
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG, "Got WOEID: " + woeId);
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG, "Got CITY: " + city);
+
+				return requestWeatherFromWoeId(woeId, weatherData);
+
+			} else {
+				throw new IOException("Placefinder failed: "
+						+ rp.getStatusLine());
+			}
+		} catch (SAXException e) {
+			throw new IOException(e);
+		} catch (ParserConfigurationException e) {
+			throw new IOException(e);
+		}
+	}
+
+	private WeatherData requestWeatherFromWoeId(String woeId,
+			WeatherData weatherData) throws IOException {
+		try {
+			String url = "http://weather.yahooapis.com/forecastrss?w=" + woeId;
+			if (Preferences.weatherCelsius) {
+				url += "&u=c";
+			}
+
+			// Ask Yahoo Weather API
+			HttpClient hc = new DefaultHttpClient();
+			HttpGet httpGet = new HttpGet(url);
+			HttpResponse rp = hc.execute(httpGet);
+			if (rp.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+				SAXParserFactory spf = SAXParserFactory.newInstance();
+				SAXParser sp = spf.newSAXParser();
+				XMLReader xr = sp.getXMLReader();
+
+				String s = EntityUtils.toString(rp.getEntity());
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG, "Got weather API response " + s);
+
+				YahooWeatherHandler handler = new YahooWeatherHandler();
+				xr.setContentHandler(handler);
+				xr.parse(new InputSource(new StringReader(s)));
+
+				weatherData.ageOfMoon = 0; // TODO
+				weatherData.celsius = Preferences.weatherCelsius;
+				weatherData.condition = handler.getText();
+				weatherData.temp = handler.getTemp();
+				weatherData.forecastTimeStamp = System.currentTimeMillis(); // TODO
+				weatherData.icon = getIcon(handler.getCode());
+				List<Forecast> forecasts = handler.getForecasts();
+				weatherData.forecast = new Forecast[forecasts.size()];
+				forecasts.toArray(weatherData.forecast);
+				weatherData.received = true;
+
+				if (Preferences.logging)
+					Log.d(MetaWatch.TAG, "Got weather data: " + weatherData);
+
+				return weatherData;
+
+			} else {
+				throw new IOException("Placefinder failed: "
+						+ rp.getStatusLine());
+			}
+		} catch (SAXException e) {
+			throw new IOException(e);
+		} catch (ParserConfigurationException e) {
+			throw new IOException(e);
+		}
+
+	}
+
+	class YahooPlacefinderHandler extends DefaultHandler {
+
+		boolean gatheringWoeId = false;
+		boolean gatheringCity = false;
+		String woeId = "";
+		String city = "";
+
+		@Override
+		public void startElement(String uri, String localName, String qName,
+				Attributes attributes) throws SAXException {
+			if (localName.equals("woeid"))
+				gatheringWoeId = true;
+			else if (localName.equals("city"))
+				gatheringCity = true;
+		}
+
+		@Override
+		public void endElement(String uri, String localName, String qName)
+				throws SAXException {
+			if (localName.equals("woeid"))
+				gatheringWoeId = false;
+			else if (localName.equals("city"))
+				gatheringCity = false;
+		}
+
+		@Override
+		public void characters(char[] ch, int start, int length)
+				throws SAXException {
+			if (gatheringWoeId)
+				woeId = new String(ch, start, length);
+			else if (gatheringCity)
+				city = new String(ch, start, length);
+		}
+
+		public String getCity() {
+			return city;
+		}
+
+		public String getWoeId() {
+			return woeId;
+		}
+
+	}
+
+	class YahooWeatherHandler extends DefaultHandler {
+		String text = "";
+		int code = 3200; // Default 3200 = "not available"
+		String temp = "";
+		List<Forecast> forecasts = new ArrayList<Forecast>();
+
+		@Override
+		public void startElement(String uri, String localName, String qName,
+				Attributes attributes) throws SAXException {
+			// if (Preferences.logging)
+			// Log.d(MetaWatch.TAG, "startElement " + localName);
+
+			if (localName.equals("condition")) {
+				// <yweather:condition text="Partly Cloudy" code="30" temp="64"
+				// date="Wed, 11 Jul 2012 10:19 am CEST" />
+				text = attributes.getValue("text");
+				code = parseCode(attributes.getValue("code"));
+				temp = attributes.getValue("temp");
+
+				Log.d(MetaWatch.TAG, "Weather Condition " + text + " " + code
+						+ " " + temp);
+
+			} else if (localName.equals("forecast")) {
+				// <yweather:forecast day="Wed" date="11 Jul 2012" low="55"
+				// high="69" text="Few Showers" code="11" />
+				Forecast fc = new Forecast();
+				fc.setTempLow(attributes.getValue("low"));
+				fc.setTempHigh(attributes.getValue("high"));
+				fc.setDay(attributes.getValue("day"));
+				fc.setIcon(getIcon(parseCode(attributes.getValue("code"))));
+				forecasts.add(fc);
+			}
+		}
+
+		public int getCode() {
+			return code;
+		}
+
+		public String getTemp() {
+			return temp;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public List<Forecast> getForecasts() {
+			return forecasts;
+		}
+
+	}
+
+	private static int parseCode(String code) {
+		try {
+			return Integer.parseInt(code.trim());
+		} catch (Exception e) {
+			return 3200;
+		}
+	}
+
+}

--- a/src/org/metawatch/manager/widgets/WeatherWidget.java
+++ b/src/org/metawatch/manager/widgets/WeatherWidget.java
@@ -6,8 +6,8 @@ import java.util.Map;
 import org.metawatch.manager.FontCache;
 import org.metawatch.manager.MetaWatchService;
 import org.metawatch.manager.MetaWatchService.Preferences;
+import org.metawatch.manager.Monitors;
 import org.metawatch.manager.Monitors.LocationData;
-import org.metawatch.manager.Monitors.WeatherData;
 import org.metawatch.manager.Utils;
 
 import android.content.Context;
@@ -151,7 +151,7 @@ public class WeatherWidget implements InternalWidget {
 			widget.height = 32;
 			
 			widget.bitmap = draw3();
-			widget.priority = WeatherData.moonPercentIlluminated !=-1 ? calcPriority() : -1;
+			widget.priority = Monitors.weatherData.moonPercentIlluminated !=-1 ? calcPriority() : -1;
 			
 			result.put(widget.id, widget);
 		}
@@ -179,7 +179,7 @@ public class WeatherWidget implements InternalWidget {
 			widget.height = 16;
 			
 			widget.bitmap = draw5();
-			widget.priority = WeatherData.moonPercentIlluminated !=-1 ? calcPriority() : -1;
+			widget.priority = Monitors.weatherData.moonPercentIlluminated !=-1 ? calcPriority() : -1;
 			
 			result.put(widget.id, widget);
 		}
@@ -219,7 +219,7 @@ public class WeatherWidget implements InternalWidget {
 		if(Preferences.weatherProvider == MetaWatchService.WeatherProvider.DISABLED)
 			return -1;
 		
-		return WeatherData.received ? 1 : 0;
+		return Monitors.weatherData.received ? 1 : 0;
 	}
 		
 	private Bitmap draw0() {
@@ -227,23 +227,23 @@ public class WeatherWidget implements InternalWidget {
 		Canvas canvas = new Canvas(bitmap);
 		canvas.drawColor(Color.WHITE);
 		
-		if (WeatherData.received && WeatherData.forecast!=null && WeatherData.forecast.length>0) {
+		if (Monitors.weatherData.received && Monitors.weatherData.forecast!=null && Monitors.weatherData.forecast.length>0) {
 			
 			// icon
-			Bitmap image = Utils.getBitmap(context, WeatherData.icon);
+			Bitmap image = Utils.getBitmap(context, Monitors.weatherData.icon);
 			canvas.drawBitmap(image, 0, 4, null);
 								
 			// temperatures
-			if (WeatherData.celsius) {
-				Utils.drawOutlinedText(WeatherData.temp+"°C", canvas, 0, 7, paintSmall, paintSmallOutline);
+			if (Monitors.weatherData.celsius) {
+				Utils.drawOutlinedText(Monitors.weatherData.temp+"°C", canvas, 0, 7, paintSmall, paintSmallOutline);
 			}
 			else {
-				Utils.drawOutlinedText(WeatherData.temp+"°F", canvas, 0, 7, paintSmall, paintSmallOutline);
+				Utils.drawOutlinedText(Monitors.weatherData.temp+"°F", canvas, 0, 7, paintSmall, paintSmallOutline);
 			}
 			paintLarge.setTextAlign(Paint.Align.LEFT);
 						
-			Utils.drawOutlinedText("H "+WeatherData.forecast[0].tempHigh, canvas, 0, 25, paintSmall, paintSmallOutline);
-			Utils.drawOutlinedText("L "+WeatherData.forecast[0].tempLow, canvas, 0, 31, paintSmall, paintSmallOutline);
+			Utils.drawOutlinedText("H "+Monitors.weatherData.forecast[0].getTempHigh(), canvas, 0, 25, paintSmall, paintSmallOutline);
+			Utils.drawOutlinedText("L "+Monitors.weatherData.forecast[0].getTempLow(), canvas, 0, 31, paintSmall, paintSmallOutline);
 									
 		} else {
 			paintSmall.setTextAlign(Paint.Align.CENTER);
@@ -261,10 +261,10 @@ public class WeatherWidget implements InternalWidget {
 		Canvas canvas = new Canvas(bitmap);
 		canvas.drawColor(Color.WHITE);
 		
-		if (WeatherData.received) {
+		if (Monitors.weatherData.received) {
 			
 			// icon
-			Bitmap image = Utils.getBitmap(context, WeatherData.icon);
+			Bitmap image = Utils.getBitmap(context, Monitors.weatherData.icon);
 			if (Preferences.overlayWeatherText)
 				canvas.drawBitmap(image, 36, 5, null);
 			else
@@ -272,15 +272,15 @@ public class WeatherWidget implements InternalWidget {
 			
 			// condition
 			if (Preferences.overlayWeatherText)
-				Utils.drawWrappedOutlinedText(WeatherData.condition, canvas, 1, 2, 60, paintSmall, paintSmallOutline, Layout.Alignment.ALIGN_NORMAL);
+				Utils.drawWrappedOutlinedText(Monitors.weatherData.condition, canvas, 1, 2, 60, paintSmall, paintSmallOutline, Layout.Alignment.ALIGN_NORMAL);
 			else
-				Utils.drawWrappedOutlinedText(WeatherData.condition, canvas, 1, 2, 34, paintSmall, paintSmallOutline, Layout.Alignment.ALIGN_NORMAL);
+				Utils.drawWrappedOutlinedText(Monitors.weatherData.condition, canvas, 1, 2, 34, paintSmall, paintSmallOutline, Layout.Alignment.ALIGN_NORMAL);
 
 			// temperatures
 			paintLarge.setTextAlign(Paint.Align.RIGHT);
 			paintLargeOutline.setTextAlign(Paint.Align.RIGHT);
-			Utils.drawOutlinedText(WeatherData.temp, canvas, 82, 13, paintLarge, paintLargeOutline);
-			if (WeatherData.celsius) {
+			Utils.drawOutlinedText(Monitors.weatherData.temp, canvas, 82, 13, paintLarge, paintLargeOutline);
+			if (Monitors.weatherData.celsius) {
 				//RM: since the degree symbol draws wrong...
 				canvas.drawText("O", 82, 7, paintSmall);
 				canvas.drawText("C", 95, 13, paintLarge);
@@ -292,17 +292,17 @@ public class WeatherWidget implements InternalWidget {
 			}
 			paintLarge.setTextAlign(Paint.Align.LEFT);
 						
-			if (WeatherData.forecast!=null && WeatherData.forecast.length>0) {
+			if (Monitors.weatherData.forecast!=null && Monitors.weatherData.forecast.length>0) {
 				canvas.drawText("High", 64, 23, paintSmall);
 				canvas.drawText("Low", 64, 31, paintSmall);
 				
 				paintSmall.setTextAlign(Paint.Align.RIGHT);
-				canvas.drawText(WeatherData.forecast[0].tempHigh, 95, 23, paintSmall);
-				canvas.drawText(WeatherData.forecast[0].tempLow, 95, 31, paintSmall);
+				canvas.drawText(Monitors.weatherData.forecast[0].getTempHigh(), 95, 23, paintSmall);
+				canvas.drawText(Monitors.weatherData.forecast[0].getTempLow(), 95, 31, paintSmall);
 				paintSmall.setTextAlign(Paint.Align.LEFT);
 			}
 
-			Utils.drawOutlinedText((String) TextUtils.ellipsize(WeatherData.locationName, paintSmall, 63, TruncateAt.END), canvas, 1, 31, paintSmall, paintSmallOutline);
+			Utils.drawOutlinedText((String) TextUtils.ellipsize(Monitors.weatherData.locationName, paintSmall, 63, TruncateAt.END), canvas, 1, 31, paintSmall, paintSmallOutline);
 						
 		} else {
 			paintSmall.setTextAlign(Paint.Align.CENTER);
@@ -331,19 +331,19 @@ public class WeatherWidget implements InternalWidget {
 		paintSmall.setTextAlign(Align.LEFT);
 		paintSmallOutline.setTextAlign(Align.LEFT);
 		
-		if (WeatherData.received && WeatherData.forecast!=null && WeatherData.forecast.length>3) {
+		if (Monitors.weatherData.received && Monitors.weatherData.forecast!=null && Monitors.weatherData.forecast.length>3) {
 			int weatherIndex = 0;
-			if(WeatherData.forecast.length>4)
+			if(Monitors.weatherData.forecast.length>4)
 				weatherIndex = 1; // Start with tomorrow's weather if we've got enough entries
 
 			for (int i=0;i<4;++i) {
 				int x = i*24;
-				Bitmap image = Utils.getBitmap(context, WeatherData.forecast[weatherIndex].icon);
+				Bitmap image = Utils.getBitmap(context, Monitors.weatherData.forecast[weatherIndex].getIcon());
 				canvas.drawBitmap(image, x, 4, null);
-				Utils.drawOutlinedText(WeatherData.forecast[weatherIndex].day, canvas, x, 6, paintSmall, paintSmallOutline);
+				Utils.drawOutlinedText(Monitors.weatherData.forecast[weatherIndex].getDay(), canvas, x, 6, paintSmall, paintSmallOutline);
 				
-				Utils.drawOutlinedText("H "+WeatherData.forecast[weatherIndex].tempHigh, canvas, x, 25, paintSmall, paintSmallOutline);
-				Utils.drawOutlinedText("L "+WeatherData.forecast[weatherIndex].tempLow, canvas, x, 31, paintSmall, paintSmallOutline);
+				Utils.drawOutlinedText("H "+Monitors.weatherData.forecast[weatherIndex].getTempHigh(), canvas, x, 25, paintSmall, paintSmallOutline);
+				Utils.drawOutlinedText("L "+Monitors.weatherData.forecast[weatherIndex].getTempLow(), canvas, x, 31, paintSmall, paintSmallOutline);
 				
 				weatherIndex++;
 			}
@@ -377,14 +377,14 @@ public class WeatherWidget implements InternalWidget {
 		
 		final boolean shouldInvert = Preferences.invertLCD || (MetaWatchService.watchType == MetaWatchService.WatchType.ANALOG);
 		
-		if (WeatherData.received && WeatherData.ageOfMoon >=0 && WeatherData.ageOfMoon < phaseImage.length ) {
-			int moonPhase = WeatherData.ageOfMoon;
+		if (Monitors.weatherData.received && Monitors.weatherData.ageOfMoon >=0 && Monitors.weatherData.ageOfMoon < phaseImage.length ) {
+			int moonPhase = Monitors.weatherData.ageOfMoon;
 			int moonImage = phaseImage[moonPhase];
 			int x = 0-(moonImage*24);
 			Bitmap image = shouldInvert ? Utils.getBitmap(context, "moon-inv.bmp") : Utils.getBitmap(context, "moon.bmp");
 			canvas.drawBitmap(image, x, 0, null);
 			
-			canvas.drawText(Integer.toString(WeatherData.moonPercentIlluminated)+"%", 12, 30, paintSmall);
+			canvas.drawText(Integer.toString(Monitors.weatherData.moonPercentIlluminated)+"%", 12, 30, paintSmall);
 		} else {
 			canvas.drawText("Wait", 12, 16, paintSmall);
 		}
@@ -399,15 +399,15 @@ public class WeatherWidget implements InternalWidget {
 		Canvas canvas = new Canvas(bitmap);
 		canvas.drawColor(Color.WHITE);
 		
-		if (WeatherData.received) {
+		if (Monitors.weatherData.received) {
 			
 			// icon
-			String smallIcon = WeatherData.icon.replace(".bmp", "_12.bmp");
+			String smallIcon = Monitors.weatherData.icon.replace(".bmp", "_12.bmp");
 			Bitmap image = Utils.getBitmap(context, smallIcon);	
 			canvas.drawBitmap(image, 46, 2, null);
 			
 			// condition
-			Utils.drawWrappedOutlinedText(WeatherData.condition, canvas, 0, 0, 60, paintSmall, paintSmallOutline, Layout.Alignment.ALIGN_NORMAL);
+			Utils.drawWrappedOutlinedText(Monitors.weatherData.condition, canvas, 0, 0, 60, paintSmall, paintSmallOutline, Layout.Alignment.ALIGN_NORMAL);
 			
 			// temperatures
 			
@@ -415,9 +415,9 @@ public class WeatherWidget implements InternalWidget {
 			paintSmallOutline.setTextAlign(Paint.Align.RIGHT);
 						
 			StringBuilder string = new StringBuilder();
-			string.append(WeatherData.temp);
+			string.append(Monitors.weatherData.temp);
 			
-			if (WeatherData.celsius) {
+			if (Monitors.weatherData.celsius) {
 				string.append("°C");
 			}
 			else {
@@ -425,18 +425,18 @@ public class WeatherWidget implements InternalWidget {
 			}
 			Utils.drawOutlinedText(string.toString(), canvas, 80, 5, paintSmall, paintSmallOutline);
 			
-			if (WeatherData.forecast!=null && WeatherData.forecast.length>0) {
+			if (Monitors.weatherData.forecast!=null && Monitors.weatherData.forecast.length>0) {
 				string = new StringBuilder();
-				string.append(WeatherData.forecast[0].tempHigh);
+				string.append(Monitors.weatherData.forecast[0].getTempHigh());
 				string.append("/");
-				string.append(WeatherData.forecast[0].tempLow);
+				string.append(Monitors.weatherData.forecast[0].getTempLow());
 						
 				Utils.drawOutlinedText(string.toString(), canvas, 80, 16, paintSmall, paintSmallOutline);
 			}
 			paintSmall.setTextAlign(Paint.Align.LEFT);
 			paintSmallOutline.setTextAlign(Paint.Align.LEFT);
 			
-			Utils.drawOutlinedText((String) TextUtils.ellipsize(WeatherData.locationName, paintSmall, 47, TruncateAt.END), canvas, 0, 16, paintSmall, paintSmallOutline);
+			Utils.drawOutlinedText((String) TextUtils.ellipsize(Monitors.weatherData.locationName, paintSmall, 47, TruncateAt.END), canvas, 0, 16, paintSmall, paintSmallOutline);
 						
 		} else {
 			paintSmall.setTextAlign(Paint.Align.CENTER);
@@ -465,8 +465,8 @@ public class WeatherWidget implements InternalWidget {
 		final boolean shouldInvert = Preferences.invertLCD || (MetaWatchService.watchType == MetaWatchService.WatchType.ANALOG);
 		
 		paintSmall.setTextAlign(Paint.Align.CENTER);
-		if (WeatherData.received && WeatherData.ageOfMoon >=0 && WeatherData.ageOfMoon < phaseImage.length) {
-			int moonPhase = WeatherData.ageOfMoon;
+		if (Monitors.weatherData.received && Monitors.weatherData.ageOfMoon >=0 && Monitors.weatherData.ageOfMoon < phaseImage.length) {
+			int moonPhase = Monitors.weatherData.ageOfMoon;
 			int moonImage = phaseImage[moonPhase];
 			int x = 0-(moonImage*16);
 			Bitmap image = shouldInvert ? Utils.getBitmap(context, "moon-inv_10.bmp") : Utils.getBitmap(context, "moon_10.bmp");
@@ -487,22 +487,22 @@ public class WeatherWidget implements InternalWidget {
 		paintSmall.setTextAlign(Align.LEFT);
 		paintSmallOutline.setTextAlign(Align.LEFT);
 		
-		if (WeatherData.received && WeatherData.forecast!=null && WeatherData.forecast.length>3) {
+		if (Monitors.weatherData.received && Monitors.weatherData.forecast!=null && Monitors.weatherData.forecast.length>3) {
 			int weatherIndex = 0;
-			if(WeatherData.forecast.length>3)
+			if(Monitors.weatherData.forecast.length>3)
 				weatherIndex = 1; // Start with tomorrow's weather if we've got enough entries
 
 			for (int i=0;i<3;++i) {
 				int x = i*26;
-				final String smallIcon = WeatherData.forecast[weatherIndex].icon.replace(".bmp", "_12.bmp");
+				final String smallIcon = Monitors.weatherData.forecast[weatherIndex].getIcon().replace(".bmp", "_12.bmp");
 				Bitmap image = Utils.getBitmap(context, smallIcon);
 				canvas.drawBitmap(image, x+12, 0, null);
-				Utils.drawOutlinedText(WeatherData.forecast[weatherIndex].day.substring(0, 2), canvas, x+1, 6, paintSmall, paintSmallOutline);
+				Utils.drawOutlinedText(Monitors.weatherData.forecast[weatherIndex].getDay().substring(0, 2), canvas, x+1, 6, paintSmall, paintSmallOutline);
 				
 				StringBuilder hilow = new StringBuilder();
-				hilow.append(WeatherData.forecast[weatherIndex].tempHigh);
+				hilow.append(Monitors.weatherData.forecast[weatherIndex].getTempHigh());
 				hilow.append("/");
-				hilow.append(WeatherData.forecast[weatherIndex].tempLow);
+				hilow.append(Monitors.weatherData.forecast[weatherIndex].getTempLow());
 				
 				Utils.drawOutlinedText(hilow.toString(), canvas, x+1, 16, paintSmallNumerals, paintSmallNumeralsOutline);
 				
@@ -533,18 +533,18 @@ public class WeatherWidget implements InternalWidget {
 		Canvas canvas = new Canvas(bitmap);
 		canvas.drawColor(Color.WHITE);
 		
-		if (WeatherData.received) {
+		if (Monitors.weatherData.received) {
 			
 			// icon
-			Bitmap image = Utils.getBitmap(context, WeatherData.icon);
+			Bitmap image = Utils.getBitmap(context, Monitors.weatherData.icon);
 			
 			canvas.drawBitmap(image, 0, 0, null);
 			
 			// temperatures
 			paintLarge.setTextAlign(Paint.Align.RIGHT);
 			paintLargeOutline.setTextAlign(Paint.Align.RIGHT);
-			Utils.drawOutlinedText(WeatherData.temp, canvas, 43, 13, paintLarge, paintLargeOutline);
-			if (WeatherData.celsius) {
+			Utils.drawOutlinedText(Monitors.weatherData.temp, canvas, 43, 13, paintLarge, paintLargeOutline);
+			if (Monitors.weatherData.celsius) {
 				canvas.drawText("C", 43, 7, paintSmall);
 			}
 			else {
@@ -552,19 +552,19 @@ public class WeatherWidget implements InternalWidget {
 			}
 			paintLarge.setTextAlign(Paint.Align.LEFT);
 						
-			if (WeatherData.forecast!=null && WeatherData.forecast.length>0) {
+			if (Monitors.weatherData.forecast!=null && Monitors.weatherData.forecast.length>0) {
 				
 				StringBuilder builder = new StringBuilder();
-				builder.append(WeatherData.forecast[0].tempHigh);
+				builder.append(Monitors.weatherData.forecast[0].getTempHigh());
 				builder.append("/");
-				builder.append(WeatherData.forecast[0].tempLow);
+				builder.append(Monitors.weatherData.forecast[0].getTempLow());
 				
 				paintSmall.setTextAlign(Paint.Align.RIGHT);
 				canvas.drawText(builder.toString(), 47, 21, paintSmall);
 				paintSmall.setTextAlign(Paint.Align.LEFT);
 			}
 
-			Utils.drawOutlinedText((String) TextUtils.ellipsize(WeatherData.locationName, paintSmall, 48, TruncateAt.END), canvas, 0, 30, paintSmall, paintSmallOutline);
+			Utils.drawOutlinedText((String) TextUtils.ellipsize(Monitors.weatherData.locationName, paintSmall, 48, TruncateAt.END), canvas, 0, 30, paintSmall, paintSmallOutline);
 						
 		} else {
 			paintSmall.setTextAlign(Paint.Align.CENTER);


### PR DESCRIPTION
- Added GeoLocation feature to Google Weather API code
- Using Apache HttpClient to query the Google API
- GoogleWeather using int instead of float temperature values. There is not enough space on Watch UI to display values behind decimal place (min/max values were truncated)
- Refactored: Moved Google/Wunderground code from Monitor class to separate impl files and created a common interface 
- Made Geo location property default true (would make initial setup easier)
- Refactored: Moved the update check (prevention of requesting weather data too often) to base class AbstractWeatherEngine
- NEW Yahoo Weather API code. It uses the weather API and placefinde API from Yahoo to request location (reverse lookup from coordinates lat/lon to address) and weather data. It requires a so called WOEID, an unique geo place id, which is required to request weather data. Such an ID can either requested for geo location (lat/lon) or an address.
