### PR TITLE
minor fix for building with ant

### DIFF
--- a/ant.properties
+++ b/ant.properties
@@ -1,0 +1,1 @@
+source.dir=src:lib-src


### PR DESCRIPTION
When you moved some source files to lib-src in commit 2c59998 you changed the classpath but you also need to add an ant.properties file because ant by default only checks in src. 
