### PR TITLE
Hidden widgets reserve space

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,9 +2,10 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
-	<classpathentry kind="lib" path="libs/bugsense-trace-1-1-2.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/bugsense-trace-1-1-2.jar"/>
 	<classpathentry kind="src" path="lib-src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,15 @@
+#Wed Oct 10 11:00:02 BST 2012
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation=0

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="MissingTranslation" severity="warning" />
+</lint>

--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -387,7 +387,14 @@
 	        android:defaultValue="false"
 			/>
 		
-		<PreferenceScreen
+	    <CheckBoxPreference
+	        android:title="@string/settings_hidden_widgets_reserve_space"
+	        android:key="HiddenWidgetsReserveSpace"
+	        android:summary="@string/settings_hidden_widgets_reserve_space_desc"
+	        android:defaultValue="false"
+			/>
+		
+	    		<PreferenceScreen
 		    android:title="@string/settings_weather_widgets"
 		    >
 	

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -235,6 +235,8 @@
     
     <string name="settings_hide_empty_widgets">Hide empty widgets</string>
     <string name="settings_hide_empty_widgets_desc">Hide widgets that are displaying "0" or have no data</string>
+    <string name="settings_hidden_widgets_reserve_space">Hidden widgets reserve space</string>
+    <string name="settings_hidden_widgets_reserve_space_desc">Hidden widgets \'reserve\' space on screen to draw themselves into once data is available</string>
     
     <string name="settings_weather_provider">Weather Provider</string>
     <string name="settings_weather_provider_desc">Choose or disable weather data source</string>

--- a/src/org/metawatch/manager/Idle.java
+++ b/src/org/metawatch/manager/Idle.java
@@ -148,8 +148,8 @@ public class Idle {
 					totalHeight += row.getHeight();
 				}
 							
-				int space = (watchType == WatchType.DIGITAL) ? (((showClock ? 64:96) - totalHeight) / (rows.size()+1)) : 0;
-				int yPos = (watchType == WatchType.DIGITAL) ? (showClock ? 32:0) + space : 0;
+				int space = (watchType == WatchType.DIGITAL) ? (((showClock ? 32:96) - totalHeight) / (rows.size()+1)) : 0;
+				int yPos = (watchType == WatchType.DIGITAL) ? (showClock ? 64:0) + space : 0;
 				
 				for(WidgetRow row : rows) {
 					row.draw(widgetData, canvas, yPos);
@@ -159,7 +159,7 @@ public class Idle {
 				if (watchType == WatchType.DIGITAL && Preferences.displayWidgetRowSeparator) {
 					yPos = space/2; // Center the separators between rows.
 					if (showClock) {
-						yPos += 32;
+						yPos += 64;
 						drawLine(canvas, yPos);
 					}
 					int i = 0;
@@ -356,7 +356,7 @@ public class Idle {
 		
 			int screenSize = 0;
 			if (MetaWatchService.watchType == MetaWatchService.WatchType.DIGITAL) {
-				screenSize = 32; // Initial screen has top part used by the fw clock
+				screenSize = 64; // Initial screen has top part used by the fw clock
 			}
 			
 			ArrayList<WidgetRow> screenRow = new ArrayList<WidgetRow>();
@@ -366,7 +366,7 @@ public class Idle {
 					screenRow = new ArrayList<WidgetRow>();
 					if (MetaWatchService.watchType == MetaWatchService.WatchType.DIGITAL &&
 							Preferences.clockOnEveryPage) {
-						screenSize = 32;
+						screenSize = 64;
 					} else { 
 						screenSize = 0;
 					}
@@ -433,9 +433,9 @@ public class Idle {
 	  Paint paint = new Paint();
 	  paint.setColor(Color.BLACK);
 
-	  int left = 3;
+	  int left = 2;
 
-	  for (int i = 0+left; i < 96-left; i += 3)
+	  for (int i = 0+left; i < 96-left; i += 4)
 	    canvas.drawLine(i, y, i+2, y, paint);
 	
 	  return canvas;

--- a/src/org/metawatch/manager/Idle.java
+++ b/src/org/metawatch/manager/Idle.java
@@ -356,7 +356,7 @@ public class Idle {
 		
 			int screenSize = 0;
 			if (MetaWatchService.watchType == MetaWatchService.WatchType.DIGITAL) {
-				screenSize = 64; // Initial screen has top part used by the fw clock
+				screenSize = 32; // Initial screen has top part used by the fw clock
 			}
 			
 			ArrayList<WidgetRow> screenRow = new ArrayList<WidgetRow>();
@@ -366,7 +366,7 @@ public class Idle {
 					screenRow = new ArrayList<WidgetRow>();
 					if (MetaWatchService.watchType == MetaWatchService.WatchType.DIGITAL &&
 							Preferences.clockOnEveryPage) {
-						screenSize = 64;
+						screenSize = 32;
 					} else { 
 						screenSize = 0;
 					}

--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -225,6 +225,7 @@ public class MetaWatchService extends Service {
 		public static boolean showActionsInCall = true;
 		public static String themeName = "";
 		public static boolean hideEmptyWidgets = false;
+		public static boolean hiddenWidgetsReserveSpace = false;
 	}
 
 	public final class WatchType {
@@ -364,6 +365,8 @@ public class MetaWatchService extends Service {
 				Preferences.themeName);
 		Preferences.hideEmptyWidgets = sharedPreferences.getBoolean("HideEmptyWidgets",
 				Preferences.hideEmptyWidgets);
+		Preferences.hiddenWidgetsReserveSpace = sharedPreferences.getBoolean("HiddenWidgetsReserveSpace",
+				Preferences.hiddenWidgetsReserveSpace);
 		
 		boolean silent = sharedPreferences.getBoolean("SilentMode", silentMode );
 		if (silent!=silentMode)

--- a/src/org/metawatch/manager/widgets/WidgetRow.java
+++ b/src/org/metawatch/manager/widgets/WidgetRow.java
@@ -39,7 +39,7 @@ public class WidgetRow {
 		
 		final int screenWidth = screenWidth();
 		
-		int priorityCutoff = Preferences.hideEmptyWidgets ? 0 : -1; 
+		int priorityCutoff = (Preferences.hideEmptyWidgets && !Preferences.hiddenWidgetsReserveSpace) ? 0 : -1; 
 		
 		totalWidth = 0;
 		for( CharSequence id : widgetIDs ) {
@@ -101,7 +101,10 @@ public class WidgetRow {
 			int yAdd = 0;
 			if(widget.height<totalHeight)
 				yAdd = (totalHeight/2)-(widget.height/2);
-			canvas.drawBitmap(widget.bitmap, x, y+yAdd, null);
+
+			if ( !(Preferences.hideEmptyWidgets && Preferences.hiddenWidgetsReserveSpace && (widget.priority < 1))) 
+				canvas.drawBitmap(widget.bitmap, x, y+yAdd, null);
+			
 			x += (space+widget.width);
 		}	
 	}


### PR DESCRIPTION
Adds additional preference option to 'Watch Widgets' screen.  Hidden widgets can now 'reserve' screen space to draw themselves into once they get data.  This allows widgets to maintain a constants position on screen, and not be affected if other widgets on the same row are hidden or not
