### PR TITLE
Widgets on top

### DIFF
--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -352,7 +352,14 @@
 			android:defaultValue="false"
 			/>
 
-		<CheckBoxPreference
+	    <CheckBoxPreference
+			android:title="@string/settings_Display_widget_icon_on_top"
+			android:key="DisplayWidgetIconOnTop"
+			android:summary="@string/settings_Display_widget_icon_on_top_desc"
+			android:defaultValue="true"
+			/>
+
+	    		<CheckBoxPreference
 			android:title="@string/settings_clock_every_page"
 			android:key="ClockOnEveryPage"
 			android:summary="@string/settings_clock_every_page_desc"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -75,7 +75,9 @@
 
     <string name="settings_Display_widget_row_separator">Display separator line</string>
     <string name="settings_Display_widget_row_separator_desc">Draws a separator line between widget rows</string>
-
+    <string name="settings_Display_widget_icon_on_top">Display widget icon on top</string>
+    <string name="settings_Display_widget_icon_on_top_desc">Draws the widget icon on the top of the row, with the value below</string>
+    
     <string name="settings_Overlay_weather_text">Overlay text in weather widget</string>
     <string name="settings_Overlay_weather_text_desc">Draws the text (condition and location) over the weather icon</string>
 

--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -225,6 +225,7 @@ public class MetaWatchService extends Service {
 		public static boolean showActionsInCall = true;
 		public static String themeName = "";
 		public static boolean hideEmptyWidgets = false;
+		public static boolean displayWidgetIconOnTop = true;
 	}
 
 	public final class WatchType {
@@ -364,6 +365,9 @@ public class MetaWatchService extends Service {
 				Preferences.themeName);
 		Preferences.hideEmptyWidgets = sharedPreferences.getBoolean("HideEmptyWidgets",
 				Preferences.hideEmptyWidgets);
+		Preferences.displayWidgetIconOnTop = sharedPreferences.getBoolean("DisplayWidgetIconOnTop", 
+				Preferences.displayWidgetIconOnTop);
+
 		
 		boolean silent = sharedPreferences.getBoolean("SilentMode", silentMode );
 		if (silent!=silentMode)

--- a/src/org/metawatch/manager/Utils.java
+++ b/src/org/metawatch/manager/Utils.java
@@ -84,6 +84,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
+import android.graphics.Point;
 import android.net.Uri;
 import android.os.Environment;
 import android.preference.PreferenceManager;
@@ -732,20 +733,52 @@ public class Utils {
 		}
 		return DrawIconStringWidget(context,width,height,icon,text,textPaint);
 	}
+	
+	public static Point getIconOffset(int rowHeight) {
+		if (rowHeight == 16) {
+			if (Preferences.displayWidgetIconOnTop) return new Point(2,0);
+			else return new Point(2,6);
+		} else if (rowHeight == 32) {
+			if (Preferences.displayWidgetIconOnTop) return new Point(0,3);
+			else return new Point(0,14);
+		} else {
+			return new Point(0,0);
+		}
+	}
+	
+	public static Point getTextOffset(int rowHeight) {
+		if (rowHeight == 16) {
+			if (Preferences.displayWidgetIconOnTop) return new Point(8,15);
+			else return new Point(8,0);
+		} else if (rowHeight == 32) {
+			if (Preferences.displayWidgetIconOnTop) return new Point(12,30);
+			else return new Point(12,12);
+		} else {
+			return new Point(0,rowHeight); //text is drawn bottom-up
+		}
+	}
 
 	public static Bitmap DrawIconStringWidget(Context context, int width, int height, Bitmap icon, String text, TextPaint textPaint) {
 		Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565);
 		Canvas canvas = new Canvas(bitmap);
 		canvas.drawColor(Color.WHITE);
 		
-		if(height==16) {
-			canvas.drawBitmap(icon, 2, 0, null);
-			canvas.drawText(text, 8, 15, textPaint);
-		}
-		else if(height==32) {
-			canvas.drawBitmap(icon, 0, 3, null);
-			canvas.drawText(text, 12, 30, textPaint);
-		}
+		Point iconOffset = getIconOffset(height);
+		Point textOffset = getTextOffset(height);
+		
+		canvas.drawBitmap(icon, iconOffset.x, iconOffset.y, null);
+		canvas.drawText(text, textOffset.x, textOffset.y, textPaint);
+		
+//		if(height==16) {
+//			canvas.drawBitmap(icon, 2, 0, null);
+//			canvas.drawText(text, 8, 15, textPaint);
+//		}
+//		else if(height==32) {
+////			canvas.drawBitmap(icon, 0, 3, null);
+////			canvas.drawText(text, 12, 30, textPaint);
+//			canvas.drawText(text, 12, 12, textPaint);
+//			canvas.drawBitmap(icon, 0, 14, null);
+//		}
 		
 		return bitmap;
 	}

--- a/src/org/metawatch/manager/widgets/CalendarWidget.java
+++ b/src/org/metawatch/manager/widgets/CalendarWidget.java
@@ -14,6 +14,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Point;
 import android.graphics.Paint.Align;
 import android.text.Layout;
 import android.text.StaticLayout;
@@ -194,33 +195,35 @@ public class CalendarWidget implements InternalWidget {
 		Canvas canvas = new Canvas(widget.bitmap);
 		canvas.drawColor(Color.WHITE);
 
+		Point iconOffset = Utils.getIconOffset(widget.height);
+		Point textOffset = Utils.getTextOffset(widget.height);
+		
 		if (widget.height == 16 && icon != null) {
-			if (icon != null)
-			canvas.drawBitmap(icon, widget.width == 16 ? 2 : 0, 0, null);
+			canvas.drawBitmap(icon, widget.width == 16 ? 2 : 0, iconOffset.y, null);
 			if(meetingTime.equals("None"))
-				canvas.drawText("-", widget.width == 16 ? 8 : 6, 15, paintSmallNumerals);
+				canvas.drawText("-", widget.width == 16 ? 8 : 6, textOffset.y, paintSmallNumerals);
 			else {
 				// Strip out colon to make it fit;
 				String time = meetingTime.replace(":", "");
 
 				if (widget.width==16) {
-					canvas.drawText(time, 8, 15, paintSmallNumerals);
+					canvas.drawText(time, 8, textOffset.y, paintSmallNumerals);
 				}
 				else {
 					paintSmallNumerals.setTextAlign(Align.LEFT);
-					canvas.drawText(time, 0, 15, paintSmallNumerals);
+					canvas.drawText(time, 0, textOffset.y, paintSmallNumerals);
 					paintSmallNumerals.setTextAlign(Align.CENTER);
 				}
 			}
 		}
 		else if (icon!=null){
-			canvas.drawBitmap(icon, 0, 3, null);
+			canvas.drawBitmap(icon, 0, iconOffset.y, null);
 
 			if ((Preferences.displayLocationInSmallCalendarWidget)&&
 					(!meetingTime.equals("None"))&&(meetingLocation!=null)&&
 					(!meetingLocation.equals("---"))&&(widget_id.equals(id_0))&&
 					(meetingLocation.length()>0)&&(meetingLocation.length()<=3)) {
-				canvas.drawText(meetingLocation, 12, 15, paintSmall);        
+				canvas.drawText(meetingLocation, 12, (iconOffset.y+13), paintSmall);        
 			}
 			else 
 			{
@@ -231,15 +234,15 @@ public class CalendarWidget implements InternalWidget {
 				}
 				int dayOfMonth = c.get(Calendar.DAY_OF_MONTH);
 				if(dayOfMonth<10) {
-					canvas.drawText(""+dayOfMonth, 12, 16, paintNumerals);
+					canvas.drawText(""+dayOfMonth, 12, (iconOffset.y+13), paintNumerals);
 				}
 				else
 				{
-					canvas.drawText(""+dayOfMonth/10, 9, 16, paintNumerals);
-					canvas.drawText(""+dayOfMonth%10, 15, 16, paintNumerals);
+					canvas.drawText(""+dayOfMonth/10, 9, (iconOffset.y+13), paintNumerals);
+					canvas.drawText(""+dayOfMonth%10, 15, (iconOffset.y+13), paintNumerals);
 				}
 			}
-			canvas.drawText(meetingTime, 12, 30, paintSmall);
+			canvas.drawText(meetingTime, 12, textOffset.y, paintSmall);
 		}
 
 		String text = "";

--- a/src/org/metawatch/manager/widgets/PhoneStatusWidget.java
+++ b/src/org/metawatch/manager/widgets/PhoneStatusWidget.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Point;
 import android.graphics.Paint.Align;
 import android.text.TextPaint;
 
@@ -90,19 +91,29 @@ public class PhoneStatusWidget implements InternalWidget {
 		Canvas canvas = new Canvas(widget.bitmap);
 		canvas.drawColor(Color.WHITE);
 		
+		int height = ((widget_id == id_0) ? 32 : 16);
+		TextPaint textPaint = ((widget_id == id_0) ? paintSmall : paintSmallNumerals);
+		Point iconOffset = Utils.getIconOffset(height);
+		Point textOffset = Utils.getTextOffset(height);
+		
+		canvas.drawBitmap(icon, iconOffset.x, iconOffset.y, null);
+		canvas.drawText(count, textOffset.x, textOffset.y, textPaint);
+
 		if (widget_id == id_0 ) {
-			canvas.drawBitmap(icon, 0, 3, null);
-			canvas.drawText(count, 12, 30,  paintSmall);
+////			canvas.drawBitmap(icon, 0, 3, null);
+////			canvas.drawText(count, 12, 30,  paintSmall);
+//			canvas.drawText(count, 12, 12, paintSmall);
+//			canvas.drawBitmap(icon, 0, 14, null);
 		
 			if(level>-1)
-				canvas.drawRect(13, 8 + ((100-level)/10), 19, 18, paintSmall);
+				canvas.drawRect((iconOffset.x+13), (iconOffset.y+5) + ((100-level)/10), (iconOffset.x+19), (iconOffset.y+15), textPaint);
 		}
 		else if (widget_id == id_1 ) {
-			canvas.drawBitmap(icon, 2, 0, null);
-			canvas.drawText(count, 8, 15,  paintSmallNumerals);
+//			canvas.drawBitmap(icon, 2, 0, null);
+//			canvas.drawText(count, 8, 15,  paintSmallNumerals);
 		
 			if(level>-1)
-				canvas.drawRect(9, 1 + ((100-level)/12), 12, 8, paintSmall);	
+				canvas.drawRect((iconOffset.x+7), (iconOffset.y+1) + ((100-level)/12), (iconOffset.x+10), (iconOffset.y+8), textPaint);	
 		}
 			
 		


### PR DESCRIPTION
Adds a new preference option to Digital Watch - the option to display widgets on the top of the row (with the value underneath) (default) or to display the text on top

Note that this change includes some refactoring of the generic Utils.drawIconStringWidget to pull the explicit left/top values out to utility functions (getIconOffset / getTextOffset).  This allows the logical for repositioning icons to be centralised, and makes the positioning available to widgets that use custom draw functions (PhoneStatus, Calendar), ensuring consistent behaviour
