### PR TITLE
first pass at making wigdet rows sink

### DIFF
--- a/res/layout/settings.xml
+++ b/res/layout/settings.xml
@@ -352,7 +352,14 @@
 			android:defaultValue="false"
 			/>
 
-		<CheckBoxPreference
+	    <CheckBoxPreference
+			android:title="@string/settings_Align_widget_row_to_bottom"
+			android:key="AlignWidgetRowToBottom"
+			android:summary="@string/settings_Align_widget_row_to_bottom_desc"
+			android:defaultValue="false"
+			/>
+
+	    		<CheckBoxPreference
 			android:title="@string/settings_clock_every_page"
 			android:key="ClockOnEveryPage"
 			android:summary="@string/settings_clock_every_page_desc"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -75,7 +75,9 @@
 
     <string name="settings_Display_widget_row_separator">Display separator line</string>
     <string name="settings_Display_widget_row_separator_desc">Draws a separator line between widget rows</string>
-
+    <string name="settings_Align_widget_row_to_bottom">Widget rows sink</string>
+    <string name="settings_Align_widget_row_to_bottom_desc">Align widget rows to the bottom of the screen</string>
+    
     <string name="settings_Overlay_weather_text">Overlay text in weather widget</string>
     <string name="settings_Overlay_weather_text_desc">Draws the text (condition and location) over the weather icon</string>
 

--- a/src/org/metawatch/manager/Idle.java
+++ b/src/org/metawatch/manager/Idle.java
@@ -150,7 +150,7 @@ public class Idle {
 							
 				float padding = 0;
 				float yPos = 0;
-				if (Preferences.alignWidgetRowToBottom) {
+				if (watchType == WatchType.DIGITAL && Preferences.alignWidgetRowToBottom) {
 					padding = 0;
 					yPos = (96 - totalHeight);
 				} else {

--- a/src/org/metawatch/manager/Idle.java
+++ b/src/org/metawatch/manager/Idle.java
@@ -148,26 +148,35 @@ public class Idle {
 					totalHeight += row.getHeight();
 				}
 							
-				final float space = (watchType == WatchType.DIGITAL) ? (float)(((showClock ? 64:96) - totalHeight) / (float)(2*rows.size())) : 0;
-				float yPos = (watchType == WatchType.DIGITAL) ? (showClock ? 30:0) + space : 0;
-				
+				float padding = 0;
+				float yPos = 0;
+				if (Preferences.alignWidgetRowToBottom) {
+					padding = 0;
+					yPos = (96 - totalHeight);
+				} else {
+					padding = (watchType == WatchType.DIGITAL) ? (float)(((showClock ? 64:96) - totalHeight) / (float)(2*rows.size())) : 0;
+					yPos = (watchType == WatchType.DIGITAL) ? (showClock ? 30:0) + padding : 0;
+				}
+				final float space = padding;
+
+				float widgetRowYPos = yPos;
 				for(WidgetRow row : rows) {
-					row.draw(widgetData, canvas, (int)yPos);
-					yPos += row.getHeight() + (space*2);
+					row.draw(widgetData, canvas, (int)widgetRowYPos);
+					widgetRowYPos += row.getHeight() + (space*2);
 				}
 	
+				float separatorYPos = yPos;
 				if (watchType == WatchType.DIGITAL && Preferences.displayWidgetRowSeparator) {
-					yPos = space/2; // Center the separators between rows.
+					separatorYPos -= space/2; // Center the separators between rows.
 					if (showClock) {
-						yPos += 30;
-						drawLine(canvas, (int)yPos);
+						drawLine(canvas, (int)separatorYPos);
 					}
 					int i = 0;
 					for(WidgetRow row : rows) {
 						if (++i == rows.size())
 							continue;
-						yPos += row.getHeight() + (space*2);
-						drawLine(canvas, (int)yPos);
+						separatorYPos += row.getHeight() + (space*2);
+						drawLine(canvas, (int)separatorYPos);
 					}
 				}
 			}

--- a/src/org/metawatch/manager/MetaWatchService.java
+++ b/src/org/metawatch/manager/MetaWatchService.java
@@ -226,6 +226,7 @@ public class MetaWatchService extends Service {
 		public static boolean showActionsInCall = true;
 		public static String themeName = "";
 		public static boolean hideEmptyWidgets = false;
+		public static boolean alignWidgetRowToBottom = false;
 	}
 
 	public final class WatchType {
@@ -365,6 +366,8 @@ public class MetaWatchService extends Service {
 				Preferences.themeName);
 		Preferences.hideEmptyWidgets = sharedPreferences.getBoolean("HideEmptyWidgets",
 				Preferences.hideEmptyWidgets);
+		Preferences.alignWidgetRowToBottom = sharedPreferences.getBoolean("AlignWidgetRowToBottom",
+				Preferences.alignWidgetRowToBottom);
 		
 		boolean silent = sharedPreferences.getBoolean("SilentMode", silentMode );
 		if (silent!=silentMode)


### PR DESCRIPTION
Adds new preference option to make widget rows 'sink' to the bottom of
the screen (removing all padding between rows).  For users with only a single row of widgets, this aligns them nicely along the bottom of the screen.  

Visually, it works even better with the 'Widgets On Top' feature (which allows icons to be toggled above there text value, or vice versa) set to display icons on the bottom, and best with the Peek theme by Prash
